### PR TITLE
Use device-local buffers with staging uploads

### DIFF
--- a/engine/include/engine/gfx/memory.hpp
+++ b/engine/include/engine/gfx/memory.hpp
@@ -29,7 +29,14 @@ struct Buffer {
 
 Buffer create_buffer(VmaAllocator alloc, VkDeviceSize size, VkBufferUsageFlags usage);
 void   destroy_buffer(VmaAllocator alloc, Buffer& buf);
-void   upload_buffer(VmaAllocator alloc, const Buffer& dst, const void* data, size_t bytes);
+// One-time upload via a transient command pool on 'queue_family' using 'queue'.
+void   upload_buffer(VmaAllocator alloc,
+                     VkDevice device,
+                     uint32_t queue_family,
+                     VkQueue queue,
+                     const Buffer& dst,
+                     const void* data,
+                     size_t bytes);
 
 // -------- Images --------
 struct Image2D {

--- a/engine/src/engine.cpp
+++ b/engine/src/engine.cpp
@@ -125,9 +125,11 @@ int run() {
   const uint16_t indices[] = { 0, 1, 2, 2, 3, 0 };
 
   Buffer vbo = create_buffer(allocator.raw(), sizeof(verts), VK_BUFFER_USAGE_VERTEX_BUFFER_BIT);
-  upload_buffer(allocator.raw(), vbo, verts, sizeof(verts));
+  upload_buffer(allocator.raw(), device.device(), device.graphics_family(), device.graphics_queue(),
+                vbo, verts, sizeof(verts));
   Buffer ibo = create_buffer(allocator.raw(), sizeof(indices), VK_BUFFER_USAGE_INDEX_BUFFER_BIT);
-  upload_buffer(allocator.raw(), ibo, indices, sizeof(indices));
+  upload_buffer(allocator.raw(), device.device(), device.graphics_family(), device.graphics_queue(),
+                ibo, indices, sizeof(indices));
 
   // Checkerboard
   const uint32_t TEX_W = 512, TEX_H = 512;


### PR DESCRIPTION
## Summary
- allocate GPU buffers with `VMA_MEMORY_USAGE_AUTO_PREFER_DEVICE` and include transfer usage
- stage CPU data through a host-visible buffer and copy with `vkCmdCopyBuffer`
- upload vertex and index data once at init using the new staging path

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "VulkanMemoryAllocator")*


------
https://chatgpt.com/codex/tasks/task_e_689ab399c4b8832a8f0925c3ca9ca674