### PR TITLE
Reuse transfer command buffer with fence synchronization

### DIFF
--- a/engine/include/engine/gfx/memory.hpp
+++ b/engine/include/engine/gfx/memory.hpp
@@ -1,7 +1,7 @@
 #pragma once
-#include <vulkan/vulkan.h>
-#include <vk_mem_alloc.h>
 #include <cstdint>
+#include <vk_mem_alloc.h>
+#include <vulkan/vulkan.h>
 
 namespace engine {
 
@@ -27,39 +27,32 @@ struct Buffer {
   VkDeviceSize size = 0;
 };
 
-Buffer create_buffer(VmaAllocator alloc, VkDeviceSize size, VkBufferUsageFlags usage);
-void   destroy_buffer(VmaAllocator alloc, Buffer& buf);
-// One-time upload via a transient command pool on 'queue_family' using 'queue'.
-void   upload_buffer(VmaAllocator alloc,
-                     VkDevice device,
-                     uint32_t queue_family,
-                     VkQueue queue,
-                     const Buffer& dst,
-                     const void* data,
-                     size_t bytes);
+Buffer create_buffer(VmaAllocator alloc, VkDeviceSize size,
+                     VkBufferUsageFlags usage);
+void destroy_buffer(VmaAllocator alloc, Buffer &buf);
+// Upload using a dedicated transfer command buffer on 'queue_family' using
+// 'queue'.
+void upload_buffer(VmaAllocator alloc, VkDevice device, uint32_t queue_family,
+                   VkQueue queue, const Buffer &dst, const void *data,
+                   size_t bytes);
 
 // -------- Images --------
 struct Image2D {
-  VkImage       image = VK_NULL_HANDLE;
+  VkImage image = VK_NULL_HANDLE;
   VmaAllocation allocation = nullptr;
-  uint32_t      width = 0, height = 0;
+  uint32_t width = 0, height = 0;
 };
 
-Image2D create_image2d(VmaAllocator alloc,
-                       uint32_t w, uint32_t h,
-                       VkFormat format,
-                       VkImageUsageFlags usage);
+Image2D create_image2d(VmaAllocator alloc, uint32_t w, uint32_t h,
+                       VkFormat format, VkImageUsageFlags usage);
 
-void destroy_image2d(VmaAllocator alloc, Image2D& img);
+void destroy_image2d(VmaAllocator alloc, Image2D &img);
 
-// One-time upload via a transient command pool on 'queue_family' using 'queue'.
-// Transitions: UNDEFINED -> TRANSFER_DST, copy, TRANSFER_DST -> SHADER_READ_ONLY.
-void upload_image2d(VmaAllocator alloc,
-                    VkDevice device,
-                    uint32_t queue_family,
-                    VkQueue queue,
-                    const void* src_rgba8,
-                    size_t src_bytes,
-                    const Image2D& dst);
+// Upload using a dedicated transfer command buffer on 'queue_family' using
+// 'queue'. Transitions: UNDEFINED -> TRANSFER_DST, copy, TRANSFER_DST ->
+// SHADER_READ_ONLY.
+void upload_image2d(VmaAllocator alloc, VkDevice device, uint32_t queue_family,
+                    VkQueue queue, const void *src_rgba8, size_t src_bytes,
+                    const Image2D &dst);
 
 } // namespace engine


### PR DESCRIPTION
## Summary
- Introduce reusable transfer command pool/command buffer with fence
- Switch buffer and image uploads to fence-based queue submission and reuse command buffer
- Update gfx memory header comments for new upload behavior

## Testing
- `cmake -S . -B build` *(fails: Could not find package VulkanMemoryAllocator)*

------
https://chatgpt.com/codex/tasks/task_e_689ab66f0be0832ab0e8887fb284e1c1