### PR TITLE
Flip viewport and enable back-face culling

### DIFF
--- a/engine/src/engine.cpp
+++ b/engine/src/engine.cpp
@@ -64,12 +64,12 @@ static void record_textured(VkCommandBuffer cmd, VkImage, VkImageView view,
 
   vkCmdBeginRendering(cmd, &ri);
 
-  // STANDARD viewport (positive height; no winding flip)
+  // Flipped viewport (negative height to keep winding consistent)
   VkViewport vp{};
   vp.x = 0.0f;
-  vp.y = 0.0f;
+  vp.y = extent.height;
   vp.width  = static_cast<float>(extent.width);
-  vp.height = static_cast<float>(extent.height);
+  vp.height = -float(extent.height);
   vp.minDepth = 0.0f; vp.maxDepth = 1.0f;
   vkCmdSetViewport(cmd, 0, 1, &vp);
 

--- a/engine/src/gfx/vulkan_pipeline.cpp
+++ b/engine/src/gfx/vulkan_pipeline.cpp
@@ -92,8 +92,8 @@ TrianglePipeline::TrianglePipeline(const TrianglePipelineCreateInfo& ci)
 
   VkPipelineRasterizationStateCreateInfo rs{ VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_CREATE_INFO };
   rs.polygonMode = VK_POLYGON_MODE_FILL;
-  rs.cullMode = VK_CULL_MODE_NONE;                  // <— disable culling to avoid winding/flip issues
-  rs.frontFace = VK_FRONT_FACE_COUNTER_CLOCKWISE;   // standard
+  rs.cullMode = VK_CULL_MODE_BACK_BIT;
+  rs.frontFace = VK_FRONT_FACE_COUNTER_CLOCKWISE;
   rs.lineWidth = 1.0f;
 
   VkPipelineMultisampleStateCreateInfo ms{ VK_STRUCTURE_TYPE_PIPELINE_MULTISAMPLE_STATE_CREATE_INFO };


### PR DESCRIPTION
## Summary
- Use a vertically flipped viewport to maintain winding
- Enable back-face culling in the Vulkan pipeline

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `./build/app/vk_app` *(fails: GLFW init failed)*

------
https://chatgpt.com/codex/tasks/task_e_689ab813c480832a9c924caf2dcc7d5f