### PR TITLE
Ensure Vulkan resources cleaned up and fix float conversions

### DIFF
--- a/engine/include/engine/gfx/memory.hpp
+++ b/engine/include/engine/gfx/memory.hpp
@@ -55,4 +55,7 @@ void upload_image2d(VmaAllocator alloc, VkDevice device, uint32_t queue_family,
                     VkQueue queue, const void *src_rgba8, size_t src_bytes,
                     const Image2D &dst);
 
+// Destroy the internal transfer context used by upload helpers.
+void destroy_transfer_context();
+
 } // namespace engine

--- a/engine/src/engine.cpp
+++ b/engine/src/engine.cpp
@@ -67,9 +67,9 @@ static void record_textured(VkCommandBuffer cmd, VkImage, VkImageView view,
   // Flipped viewport (negative height to keep winding consistent)
   VkViewport vp{};
   vp.x = 0.0f;
-  vp.y = extent.height;
+  vp.y = static_cast<float>(extent.height);
   vp.width  = static_cast<float>(extent.width);
-  vp.height = -float(extent.height);
+  vp.height = -static_cast<float>(extent.height);
   vp.minDepth = 0.0f; vp.maxDepth = 1.0f;
   vkCmdSetViewport(cmd, 0, 1, &vp);
 
@@ -78,7 +78,8 @@ static void record_textured(VkCommandBuffer cmd, VkImage, VkImageView view,
 
   vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_GRAPHICS, ctx->pipe->pipeline());
 
-  float aspect = extent.width / (extent.height > 0 ? float(extent.height) : 1.0f);
+  float aspect = static_cast<float>(extent.width) /
+                 (extent.height > 0 ? static_cast<float>(extent.height) : 1.0f);
   vkCmdPushConstants(cmd, ctx->pipe->layout(), VK_SHADER_STAGE_VERTEX_BIT, 0, sizeof(float), &aspect);
 
   VkBuffer vbos[] = { ctx->vbo };
@@ -259,6 +260,7 @@ int run() {
   destroy_image2d(allocator.raw(), img);
   destroy_buffer(allocator.raw(), ibo);
   destroy_buffer(allocator.raw(), vbo);
+  destroy_transfer_context();
   allocator.destroy();
 
   spdlog::info("Shutdown.");

--- a/engine/src/gfx/memory.cpp
+++ b/engine/src/gfx/memory.cpp
@@ -257,9 +257,21 @@ void upload_image2d(VmaAllocator alloc, VkDevice device, uint32_t queue_family,
   si.pCommandBuffers = &g_transfer.cmd;
   VK_CHECK(vkResetFences(device, 1, &g_transfer.fence));
   VK_CHECK(vkQueueSubmit(queue, 1, &si, g_transfer.fence));
-  VK_CHECK(vkWaitForFences(device, 1, &g_transfer.fence, VK_TRUE, UINT64_MAX));
+    VK_CHECK(vkWaitForFences(device, 1, &g_transfer.fence, VK_TRUE, UINT64_MAX));
 
-  vmaDestroyBuffer(alloc, stagingBuf, stagingAlloc);
+    vmaDestroyBuffer(alloc, stagingBuf, stagingAlloc);
+  }
+
+void destroy_transfer_context() {
+  if (!g_transfer.pool && !g_transfer.fence)
+    return;
+  if (g_transfer.cmd)
+    vkFreeCommandBuffers(g_transfer.device, g_transfer.pool, 1, &g_transfer.cmd);
+  if (g_transfer.pool)
+    vkDestroyCommandPool(g_transfer.device, g_transfer.pool, nullptr);
+  if (g_transfer.fence)
+    vkDestroyFence(g_transfer.device, g_transfer.fence, nullptr);
+  g_transfer = {};
 }
 
 } // namespace engine


### PR DESCRIPTION
## Summary
- cast extent dimensions to float to avoid precision warnings
- release transfer command resources before destroying the device

## Testing
- `cmake -S . -B build`
- `cmake --build build`


------
https://chatgpt.com/codex/tasks/task_e_689abb31f100832a94f0fae2be820689