### PR TITLE
Use timeline semaphore for frame sync

### DIFF
--- a/engine/include/engine/gfx/vulkan_commands.hpp
+++ b/engine/include/engine/gfx/vulkan_commands.hpp
@@ -43,8 +43,6 @@ private:
   uint32_t  gfx_family_ = ~0u;
 
   struct Frame {
-    VkSemaphore     image_available = VK_NULL_HANDLE;
-    VkSemaphore     render_finished = VK_NULL_HANDLE;
     VkFence         in_flight = VK_NULL_HANDLE;
     VkCommandPool   cmd_pool = VK_NULL_HANDLE;
     VkCommandBuffer cmd      = VK_NULL_HANDLE;
@@ -52,6 +50,9 @@ private:
   };
   std::vector<Frame> frames_;
   uint32_t frame_cursor_ = 0;
+
+  VkSemaphore timeline_ = VK_NULL_HANDLE;
+  uint64_t    timeline_value_ = 0;
 };
 
 } // namespace engine

--- a/engine/src/gfx/vulkan_commands.cpp
+++ b/engine/src/gfx/vulkan_commands.cpp
@@ -18,11 +18,15 @@ VulkanCommands::VulkanCommands(const VulkanCommandsCreateInfo& ci)
 {
   frames_.resize(std::max<uint32_t>(ci.image_count, 1u));
 
-  for (auto& f : frames_) {
-    VkSemaphoreCreateInfo si{ VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO };
-    VK_CHECK(vkCreateSemaphore(dev_, &si, nullptr, &f.image_available));
-    VK_CHECK(vkCreateSemaphore(dev_, &si, nullptr, &f.render_finished));
+  // Create timeline semaphore used for image acquisition and rendering sync
+  VkSemaphoreTypeCreateInfo tsci{ VK_STRUCTURE_TYPE_SEMAPHORE_TYPE_CREATE_INFO };
+  tsci.semaphoreType = VK_SEMAPHORE_TYPE_TIMELINE;
+  tsci.initialValue = 0;
+  VkSemaphoreCreateInfo sci{ VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO };
+  sci.pNext = &tsci;
+  VK_CHECK(vkCreateSemaphore(dev_, &sci, nullptr, &timeline_));
 
+  for (auto& f : frames_) {
     VkFenceCreateInfo fi{ VK_STRUCTURE_TYPE_FENCE_CREATE_INFO };
     fi.flags = VK_FENCE_CREATE_SIGNALED_BIT; // start signaled
     VK_CHECK(vkCreateFence(dev_, &fi, nullptr, &f.in_flight));
@@ -48,9 +52,8 @@ VulkanCommands::~VulkanCommands() {
     if (f.cmd)        vkFreeCommandBuffers(dev_, f.cmd_pool, 1, &f.cmd);
     if (f.cmd_pool)   vkDestroyCommandPool(dev_, f.cmd_pool, nullptr);
     if (f.in_flight)  vkDestroyFence(dev_, f.in_flight, nullptr);
-    if (f.render_finished) vkDestroySemaphore(dev_, f.render_finished, nullptr);
-    if (f.image_available) vkDestroySemaphore(dev_, f.image_available, nullptr);
   }
+  if (timeline_) vkDestroySemaphore(dev_, timeline_, nullptr);
 }
 
 uint32_t VulkanCommands::acquire_record_present(
@@ -72,7 +75,8 @@ uint32_t VulkanCommands::acquire_record_present(
 
   // Acquire image
   uint32_t image_index = 0;
-  VkResult acq = vkAcquireNextImageKHR(dev_, swapchain, UINT64_MAX, f.image_available, VK_NULL_HANDLE, &image_index);
+  uint64_t acquire_value = ++timeline_value_;
+  VkResult acq = vkAcquireNextImageKHR(dev_, swapchain, UINT64_MAX, timeline_, VK_NULL_HANDLE, &image_index);
   if (acq == VK_ERROR_OUT_OF_DATE_KHR) {
     spdlog::warn("[vk] Acquire returned OUT_OF_DATE (resize will recreate).");
     return image_index;
@@ -132,22 +136,33 @@ uint32_t VulkanCommands::acquire_record_present(
   f.first_use = false;
 
   // Submit
+  uint64_t render_value = ++timeline_value_;
+  VkTimelineSemaphoreSubmitInfo ts{ VK_STRUCTURE_TYPE_TIMELINE_SEMAPHORE_SUBMIT_INFO };
+  ts.waitSemaphoreValueCount = 1;
+  ts.pWaitSemaphoreValues = &acquire_value;
+  ts.signalSemaphoreValueCount = 1;
+  ts.pSignalSemaphoreValues = &render_value;
+
   VkPipelineStageFlags wait_stage = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
-  VkSubmitInfo si{ VK_STRUCTURE_TYPE_SUBMIT_INFO };
+  VkSubmitInfo si{ VK_STRUCTURE_TYPE_SUBMIT_INFO, &ts };
   si.waitSemaphoreCount = 1;
-  si.pWaitSemaphores = &f.image_available;
+  si.pWaitSemaphores = &timeline_;
   si.pWaitDstStageMask = &wait_stage;
   si.commandBufferCount = 1;
   si.pCommandBuffers = &f.cmd;
   si.signalSemaphoreCount = 1;
-  si.pSignalSemaphores = &f.render_finished;
+  si.pSignalSemaphores = &timeline_;
 
   VK_CHECK(vkQueueSubmit(graphics_queue, 1, &si, f.in_flight));
 
   // Present
-  VkPresentInfoKHR pi{ VK_STRUCTURE_TYPE_PRESENT_INFO_KHR };
+  VkTimelineSemaphoreSubmitInfo pts{ VK_STRUCTURE_TYPE_TIMELINE_SEMAPHORE_SUBMIT_INFO };
+  pts.waitSemaphoreValueCount = 1;
+  pts.pWaitSemaphoreValues = &render_value;
+
+  VkPresentInfoKHR pi{ VK_STRUCTURE_TYPE_PRESENT_INFO_KHR, &pts };
   pi.waitSemaphoreCount = 1;
-  pi.pWaitSemaphores = &f.render_finished;
+  pi.pWaitSemaphores = &timeline_;
   pi.swapchainCount = 1;
   pi.pSwapchains = &swapchain;
   pi.pImageIndices = &image_index;

--- a/engine/src/gfx/vulkan_device.cpp
+++ b/engine/src/gfx/vulkan_device.cpp
@@ -128,18 +128,21 @@ void VulkanDevice::create_logical(bool enable_validation) {
   
     VkPhysicalDeviceFeatures feats{}; // keep default
   
-    // Dynamic rendering feature (Vulkan 1.3 core)
+    // Dynamic rendering and timeline semaphore features
     VkPhysicalDeviceDynamicRenderingFeatures dyn{ VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DYNAMIC_RENDERING_FEATURES };
     dyn.dynamicRendering = VK_TRUE;
-  
-    const char* kExts[] = { VK_KHR_SWAPCHAIN_EXTENSION_NAME };
-  
+    VkPhysicalDeviceTimelineSemaphoreFeatures timeline{ VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TIMELINE_SEMAPHORE_FEATURES };
+    timeline.timelineSemaphore = VK_TRUE;
+    timeline.pNext = &dyn;
+
+    const char* kExts[] = { VK_KHR_SWAPCHAIN_EXTENSION_NAME, VK_KHR_TIMELINE_SEMAPHORE_EXTENSION_NAME };
+
     VkDeviceCreateInfo di{ VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO };
-    di.pNext = &dyn;
+    di.pNext = &timeline;
     di.queueCreateInfoCount = static_cast<uint32_t>(qinfos.size());
     di.pQueueCreateInfos = qinfos.data();
     di.pEnabledFeatures = &feats;
-    di.enabledExtensionCount = 1;
+    di.enabledExtensionCount = 2;
     di.ppEnabledExtensionNames = kExts;
   
     VK_CHECK(vkCreateDevice(phys_, &di, nullptr, &dev_));


### PR DESCRIPTION
## Summary
- replace per-frame binary semaphores with a single timeline semaphore in VulkanCommands
- wait/signal increasing semaphore values when acquiring images, submitting work and presenting
- enable Vulkan timeline semaphore feature and extension on device creation

## Testing
- `cmake -S . -B build`
- `cmake --build build`

------
https://chatgpt.com/codex/tasks/task_e_689abfb09f88832a8453c85c48157f08