### PR TITLE
Use timeline semaphore with binary WSI sync

### DIFF
--- a/engine/include/engine/gfx/vulkan_commands.hpp
+++ b/engine/include/engine/gfx/vulkan_commands.hpp
@@ -45,13 +45,16 @@ private:
   struct Frame {
     VkSemaphore     image_available = VK_NULL_HANDLE;
     VkSemaphore     render_finished = VK_NULL_HANDLE;
-    VkFence         in_flight = VK_NULL_HANDLE;
     VkCommandPool   cmd_pool = VK_NULL_HANDLE;
     VkCommandBuffer cmd      = VK_NULL_HANDLE;
+    uint64_t        finished_value = 0; // timeline value signaled when frame completes
     bool            first_use = true;
   };
   std::vector<Frame> frames_;
   uint32_t frame_cursor_ = 0;
+
+  VkSemaphore timeline_ = VK_NULL_HANDLE;
+  uint64_t    timeline_value_ = 0;
 };
 
 } // namespace engine

--- a/engine/src/gfx/vulkan_device.cpp
+++ b/engine/src/gfx/vulkan_device.cpp
@@ -128,18 +128,21 @@ void VulkanDevice::create_logical(bool enable_validation) {
   
     VkPhysicalDeviceFeatures feats{}; // keep default
   
-    // Dynamic rendering feature (Vulkan 1.3 core)
+    // Dynamic rendering and timeline semaphore features
     VkPhysicalDeviceDynamicRenderingFeatures dyn{ VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DYNAMIC_RENDERING_FEATURES };
     dyn.dynamicRendering = VK_TRUE;
-  
-    const char* kExts[] = { VK_KHR_SWAPCHAIN_EXTENSION_NAME };
-  
+    VkPhysicalDeviceTimelineSemaphoreFeatures timeline{ VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TIMELINE_SEMAPHORE_FEATURES };
+    timeline.timelineSemaphore = VK_TRUE;
+    timeline.pNext = &dyn;
+
+    const char* kExts[] = { VK_KHR_SWAPCHAIN_EXTENSION_NAME, VK_KHR_TIMELINE_SEMAPHORE_EXTENSION_NAME };
+
     VkDeviceCreateInfo di{ VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO };
-    di.pNext = &dyn;
+    di.pNext = &timeline;
     di.queueCreateInfoCount = static_cast<uint32_t>(qinfos.size());
     di.pQueueCreateInfos = qinfos.data();
     di.pEnabledFeatures = &feats;
-    di.enabledExtensionCount = 1;
+    di.enabledExtensionCount = 2;
     di.ppEnabledExtensionNames = kExts;
   
     VK_CHECK(vkCreateDevice(phys_, &di, nullptr, &dev_));


### PR DESCRIPTION
## Summary
- track frame completion with a single timeline semaphore while keeping per-frame binary semaphores for swapchain acquire/present
- wait on timeline values before reusing frames and signal both binary and timeline semaphores during submission
- present using a binary semaphore as required by the Vulkan spec

## Testing
- `cmake -S . -B build`
- `cmake --build build`


------
https://chatgpt.com/codex/tasks/task_e_689abfb09f88832a8453c85c48157f08