### PR TITLE
Implement naive uniform grid raycaster

### DIFF
--- a/assets/shaders/pp_raycast.comp
+++ b/assets/shaders/pp_raycast.comp
@@ -2,16 +2,84 @@
 layout (local_size_x=8, local_size_y=8) in;
 layout (rgba16f, binding=0) writeonly uniform image2D outImg;
 
+layout(binding=2) uniform usampler3D uOccGrid;
+
 layout (std140, binding=1) uniform Camera {
     mat4 invViewProj;
     vec2 resolution;
     float time;
+    float _pad;
+    vec4 worldMin;
+    vec4 worldMax;
 } cam;
+
+struct Ray { vec3 o; vec3 d; };
+
+Ray makeRay(ivec2 p){
+    vec2 ndc = (vec2(p)+0.5)/cam.resolution*2.0-1.0;
+    vec4 h0 = cam.invViewProj * vec4(ndc, 0, 1);
+    vec4 h1 = cam.invViewProj * vec4(ndc, 1, 1);
+    vec3 ro = h0.xyz / h0.w;
+    vec3 rd = normalize(h1.xyz / h1.w - ro);
+    return Ray(ro, rd);
+}
+
+bool gridRaycast(Ray r, out ivec3 cell, out int hitFace){
+    vec3 invD = 1.0 / r.d;
+    vec3 t0s = (cam.worldMin.xyz - r.o) * invD;
+    vec3 t1s = (cam.worldMax.xyz - r.o) * invD;
+    vec3 tsm = min(t0s, t1s);
+    vec3 tsM = max(t0s, t1s);
+    float t0 = max(max(tsm.x, tsm.y), tsm.z);
+    float t1 = min(min(tsM.x, tsM.y), tsM.z);
+    if (t1 <= max(t0, 0.0)) return false;
+    float t = max(t0, 0.0);
+    vec3 pos = r.o + t * r.d;
+
+    ivec3 gridSize = textureSize(uOccGrid, 0);
+    vec3 rel = (pos - cam.worldMin.xyz) / (cam.worldMax.xyz - cam.worldMin.xyz);
+    vec3 cellf = rel * vec3(gridSize);
+    cell = ivec3(clamp(floor(cellf), vec3(0.0), vec3(gridSize) - vec3(1.0)));
+
+    ivec3 step = ivec3(greaterThan(r.d, vec3(0.0))) * 2 - ivec3(1);
+    vec3 cellSize = (cam.worldMax.xyz - cam.worldMin.xyz) / vec3(gridSize);
+    vec3 next = cam.worldMin.xyz + (vec3(cell) + (vec3(step) + 1.0) * 0.5) * cellSize;
+    vec3 tMax = (next - pos) / r.d;
+    vec3 tDelta = cellSize / abs(r.d);
+    hitFace = -1;
+    for(int i=0;i<1024;i++){
+        if(any(lessThan(cell, ivec3(0))) || any(greaterThanEqual(cell, gridSize))) break;
+        if(texelFetch(uOccGrid, cell, 0).r > 0u) return true;
+        if(tMax.x < tMax.y){
+            if(tMax.x < tMax.z){
+                cell.x += step.x; tMax.x += tDelta.x; hitFace = step.x > 0 ? 0 : 1;
+            }else{
+                cell.z += step.z; tMax.z += tDelta.z; hitFace = step.z > 0 ? 4 : 5;
+            }
+        }else{
+            if(tMax.y < tMax.z){
+                cell.y += step.y; tMax.y += tDelta.y; hitFace = step.y > 0 ? 2 : 3;
+            }else{
+                cell.z += step.z; tMax.z += tDelta.z; hitFace = step.z > 0 ? 4 : 5;
+            }
+        }
+    }
+    return false;
+}
 
 void main(){
     ivec2 p = ivec2(gl_GlobalInvocationID.xy);
     if (any(greaterThanEqual(p, ivec2(cam.resolution)))) return;
-    bool c = ((((p.x >> 4) ^ (p.y >> 4)) & 1) == 1);
-    vec3 col = c ? vec3(0.95,0.94,0.78) : vec3(0.44,0.52,0.98);
+    Ray r = makeRay(p);
+    ivec3 cell; int face;
+    vec3 col = vec3(0.0);
+    if(gridRaycast(r, cell, face)){
+        const vec3 cols[6] = vec3[6](
+            vec3(1,0,0), vec3(0,1,0),
+            vec3(0,0,1), vec3(1,1,0),
+            vec3(1,0,1), vec3(0,1,1)
+        );
+        col = cols[face];
+    }
     imageStore(outImg, p, vec4(col,1));
 }

--- a/engine/include/engine/gfx/memory.hpp
+++ b/engine/include/engine/gfx/memory.hpp
@@ -56,6 +56,19 @@ void upload_image2d(VmaAllocator alloc, VkDevice device, uint32_t queue_family,
                     VkQueue queue, const void *src_rgba8, size_t src_bytes,
                     const Image2D &dst);
 
+struct Image3D {
+  VkImage image = VK_NULL_HANDLE;
+  VmaAllocation allocation = nullptr;
+  uint32_t width = 0, height = 0, depth = 0;
+};
+
+Image3D create_image3d(VmaAllocator alloc, uint32_t w, uint32_t h, uint32_t d,
+                       VkFormat format, VkImageUsageFlags usage);
+void destroy_image3d(VmaAllocator alloc, Image3D &img);
+void upload_image3d(VmaAllocator alloc, VkDevice device, uint32_t queue_family,
+                    VkQueue queue, const void *src, size_t src_bytes,
+                    const Image3D &dst);
+
 // Destroy the internal transfer context used by upload helpers.
 void destroy_transfer_context();
 


### PR DESCRIPTION
## Summary
- Cast one ray per pixel through a dense 3D occupancy grid
- Add 3D image helpers and upload a simple voxel scene
- Wire compute shader and descriptor bindings to perform DDA ray march

## Testing
- `cmake ..`
- `cmake --build .`


------
https://chatgpt.com/codex/tasks/task_e_689b3083cdd8832a85b208b44a43a193