### PR TITLE
Add voxel raycasting to fullscreen fragment shader

### DIFF
--- a/assets/shaders/fs_present.frag
+++ b/assets/shaders/fs_present.frag
@@ -1,7 +1,84 @@
 #version 460
-layout(location=0) in vec2 vUV;
 layout(location=0) out vec4 outColor;
-layout(binding=0) uniform sampler2D uComputeColor;
+
+layout(set=0, binding=0, std140) uniform Camera {
+    mat4 invViewProj;
+    vec2 resolution;
+    float time;
+    float _pad;
+} cam;
+
+layout(set=0, binding=1, std140) uniform VoxelAABB {
+    vec3 min; float pad0;
+    vec3 max; float pad1;
+    ivec3 dim; int pad2;
+} vox;
+
+layout(set=0, binding=2) uniform usampler3D uOccTex;
+
+struct Ray { vec3 o; vec3 d; };
+
+Ray makeRay(vec2 p) {
+    vec2 ndc = (p / cam.resolution) * 2.0 - 1.0;
+    vec4 h0 = cam.invViewProj * vec4(ndc, 0.0, 1.0);
+    vec4 h1 = cam.invViewProj * vec4(ndc, 1.0, 1.0);
+    vec3 ro = h0.xyz / h0.w;
+    vec3 rd = normalize(h1.xyz / h1.w - ro);
+    return Ray(ro, rd);
+}
+
+bool gridRaycast(Ray r, out int hitFace) {
+    vec3 invD = 1.0 / r.d;
+    vec3 t0s = (vox.min - r.o) * invD;
+    vec3 t1s = (vox.max - r.o) * invD;
+    vec3 tsm = min(t0s, t1s);
+    vec3 tsM = max(t0s, t1s);
+    float t0 = max(max(tsm.x, tsm.y), tsm.z);
+    float t1 = min(min(tsM.x, tsM.y), tsM.z);
+    if (t1 <= max(t0, 0.0)) return false;
+    float t = max(t0, 0.0);
+    vec3 pos = r.o + t * r.d;
+
+    vec3 cellf = (pos - vox.min) / (vox.max - vox.min) * vec3(vox.dim);
+    ivec3 cell = ivec3(clamp(floor(cellf), vec3(0.0), vec3(vox.dim) - vec3(1.0)));
+
+    ivec3 step = ivec3(greaterThan(r.d, vec3(0.0))) * 2 - ivec3(1);
+    vec3 cellSize = (vox.max - vox.min) / vec3(vox.dim);
+    vec3 next = vox.min + (vec3(cell) + (vec3(step)+1.0)*0.5) * cellSize;
+    vec3 tMax = (next - pos) / r.d;
+    vec3 tDelta = cellSize / abs(r.d);
+    hitFace = -1;
+    for(int i=0;i<1024;i++){
+        if(any(lessThan(cell, ivec3(0))) || any(greaterThanEqual(cell, vox.dim))) break;
+        if(texelFetch(uOccTex, cell, 0).r > 0u) return true;
+        if(tMax.x < tMax.y){
+            if(tMax.x < tMax.z){
+                cell.x += step.x; tMax.x += tDelta.x; hitFace = step.x > 0 ? 0 : 1;
+            }else{
+                cell.z += step.z; tMax.z += tDelta.z; hitFace = step.z > 0 ? 4 : 5;
+            }
+        }else{
+            if(tMax.y < tMax.z){
+                cell.y += step.y; tMax.y += tDelta.y; hitFace = step.y > 0 ? 2 : 3;
+            }else{
+                cell.z += step.z; tMax.z += tDelta.z; hitFace = step.z > 0 ? 4 : 5;
+            }
+        }
+    }
+    return false;
+}
+
 void main() {
-    outColor = texture(uComputeColor, vUV);
+    Ray r = makeRay(gl_FragCoord.xy);
+    int face;
+    vec3 col = vec3(0.0);
+    if (gridRaycast(r, face)) {
+        const vec3 cols[6] = vec3[6](
+            vec3(1,0,0), vec3(0,1,0),
+            vec3(0,0,1), vec3(1,1,0),
+            vec3(1,0,1), vec3(0,1,1)
+        );
+        col = cols[face];
+    }
+    outColor = vec4(col, 1.0);
 }

--- a/engine/include/engine/gfx/present_pipeline.hpp
+++ b/engine/include/engine/gfx/present_pipeline.hpp
@@ -12,8 +12,11 @@ struct PresentPipelineCreateInfo {
   std::string fs_spv;
 };
 
-// Graphics pipeline for a fullscreen triangle sampling a texture.
-// Descriptor set layout: set0,binding0 combined image sampler.
+// Graphics pipeline for a fullscreen triangle performing voxel raycasting.
+// Descriptor set layout:
+//   set0,binding0 uniform buffer    (CameraUBO)
+//   set0,binding1 uniform buffer    (VoxelAABB)
+//   set0,binding2 combined sampler  (3D occupancy texture)
 class PresentPipeline {
 public:
   explicit PresentPipeline(const PresentPipelineCreateInfo& ci);

--- a/engine/src/gfx/present_pipeline.cpp
+++ b/engine/src/gfx/present_pipeline.cpp
@@ -28,15 +28,25 @@ VkShaderModule PresentPipeline::load_module(const std::string& path) {
 
 PresentPipeline::PresentPipeline(const PresentPipelineCreateInfo& ci)
   : dev_(ci.device), color_format_(ci.color_format) {
-  // Descriptor set layout: set0,binding0 combined image sampler (fragment)
-  VkDescriptorSetLayoutBinding sam{};
-  sam.binding = 0;
-  sam.descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
-  sam.descriptorCount = 1;
-  sam.stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT;
+  // Descriptor set layout for camera UBO, voxel AABB UBO and occupancy texture
+  VkDescriptorSetLayoutBinding binds[3]{};
+  binds[0].binding = 0;
+  binds[0].descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
+  binds[0].descriptorCount = 1;
+  binds[0].stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT;
+
+  binds[1].binding = 1;
+  binds[1].descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
+  binds[1].descriptorCount = 1;
+  binds[1].stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT;
+
+  binds[2].binding = 2;
+  binds[2].descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
+  binds[2].descriptorCount = 1;
+  binds[2].stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT;
 
   VkDescriptorSetLayoutCreateInfo dlci{ VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO };
-  dlci.bindingCount = 1; dlci.pBindings = &sam;
+  dlci.bindingCount = 3; dlci.pBindings = binds;
   VK_CHECK(vkCreateDescriptorSetLayout(dev_, &dlci, nullptr, &dset_layout_));
 
   // Pipeline layout: only descriptor set layout (no push constants)


### PR DESCRIPTION
## Summary
- Replace fullscreen fragment shader with Amanatides & Woo DDA ray traversal through 128³ occupancy texture
- Introduce VoxelAABB UBO and CPU-side generation/upload of test voxel grid
- Update present pipeline descriptors and engine setup for camera, voxel bounds, and occupancy texture

## Testing
- `cmake -S . -B build`
- `cmake --build build`


------
https://chatgpt.com/codex/tasks/task_e_689b3f5f6b78832a9cb1586b841c793d