### PR TITLE
Add GPU voxel editing modes and live controls

### DIFF
--- a/assets/shaders/procgen_voxels.comp
+++ b/assets/shaders/procgen_voxels.comp
@@ -1,38 +1,70 @@
 #version 460
 layout (local_size_x=8, local_size_y=8, local_size_z=8) in;
 
-layout (r8ui, binding=0) writeonly uniform uimage3D occOut;
+// Storage image we can both read and write for OR/AND updates
+layout (r8ui, binding=0) uniform uimage3D occOut;
+
+// Modes for P.mode
+const int MODE_CLEAR       = 0;
+const int MODE_FILL_BOX    = 1;
+const int MODE_FILL_SPHERE = 2;
+const int MODE_NOISE       = 3;
+
+// Ops for P.op
+const int OP_REPLACE = 0;
+const int OP_OR      = 1;
+const int OP_AND     = 2;
 
 layout (std140, binding=1) uniform VoxParams {
     ivec3 dim;   int frame;
     vec3  volMin; float pad0;
     vec3  volMax; float pad1;
     // shape params
-    vec3 boxA; float pad2;
-    vec3 boxB; float pad3;
+    vec3 boxCenter; float pad2;
+    vec3 boxHalf;   float pad3;
     vec3 sphereCenter; float sphereRadius;
+    int mode; int op; int noiseSeed; int pad4;
 } P;
+
+float hash(vec3 p, float seed){
+    return fract(sin(dot(p, vec3(12.9898,78.233,37.719)) + seed) * 43758.5453);
+}
 
 void main(){
     ivec3 p = ivec3(gl_GlobalInvocationID.xyz);
     if (any(greaterThanEqual(p, P.dim))) return;
 
-    // Example: union of a box and a sphere (both in voxel coordinates)
-    uint v = 0u;
+    uint shape = 0u;
+    vec3 pf = vec3(p) + 0.5;
 
-    // Box test
-    bvec3 inA = greaterThanEqual(p, ivec3(floor(P.boxA)));
-    bvec3 inB = lessThanEqual   (p, ivec3(floor(P.boxB)));
-    if (all(inA) && all(inB)) v = 1u;
+    if(P.mode == MODE_FILL_BOX || P.mode == MODE_CLEAR ||
+       P.mode == MODE_FILL_SPHERE || P.mode == MODE_NOISE){
+        // compute shape occupancy
+        if(P.mode == MODE_FILL_BOX){
+            bvec3 inA = greaterThanEqual(pf, P.boxCenter - P.boxHalf);
+            bvec3 inB = lessThanEqual   (pf, P.boxCenter + P.boxHalf);
+            if(all(inA) && all(inB)) shape = 1u;
+        }else if(P.mode == MODE_FILL_SPHERE){
+            float d2 = dot(pf - P.sphereCenter, pf - P.sphereCenter);
+            if(d2 <= P.sphereRadius * P.sphereRadius) shape = 1u;
+        }else if(P.mode == MODE_NOISE){
+            float n = hash(pf*0.08, float(P.noiseSeed));
+            if(n < 0.5) shape = 1u; else shape = 0u;
+        }
+    }
 
-    // Sphere test
-    vec3  pf = vec3(p) + 0.5;
-    float d2 = dot(pf - P.sphereCenter, pf - P.sphereCenter);
-    if (d2 <= P.sphereRadius * P.sphereRadius) v = 1u;
-
-    // (Optional) animated noise cutout
-    // float n = noise3D(pf*0.08 + vec3(P.frame*0.02));
-    // if (n < 0.45) v = 0u;
-
+    uint prev = imageLoad(occOut, p).r;
+    uint v = prev;
+    if(P.mode == MODE_CLEAR){
+        v = 0u;
+    }else{
+        if(P.op == OP_REPLACE){
+            v = shape;
+        }else if(P.op == OP_OR){
+            v = max(prev, shape);
+        }else if(P.op == OP_AND){
+            v = min(prev, 1u - shape);
+        }
+    }
     imageStore(occOut, p, uvec4(v,0,0,0));
 }


### PR DESCRIPTION
## Summary
- Add mode/op fields to voxel shader to support clear/fill/noise and OR/AND editing
- Enable runtime hotkeys to move/resize shapes and tweak noise seed without CPU voxel buffers

## Testing
- `cmake -S . -B build`
- `cmake --build build`


------
https://chatgpt.com/codex/tasks/task_e_689b484d5cac832a8f9fb907894b8ec1