### PR TITLE
feat: add material id sidecar for coloring

### DIFF
--- a/assets/shaders/fs_present.frag
+++ b/assets/shaders/fs_present.frag
@@ -122,9 +122,10 @@ void main() {
     vec3 col = vec3(0.0);
     if (gridRaycast(r, cell, face)) {
         uint m = texelFetch(uMatTex, cell, 0).r;
-        if(m == 1u) col = vec3(0.55,0.27,0.07); // terrain
-        else if(m == 2u) col = vec3(0.1,0.8,0.1); // tree
-        else col = vec3(1.0);
+        if(m == 1u)      col = vec3(0.55,0.27,0.07); // terrain
+        else if(m == 2u) col = vec3(0.1,0.8,0.1);    // foliage
+        else if(m == 3u) col = vec3(0.5,0.5,0.5);    // rock
+        else             col = vec3(1.0);
     }
     outColor = vec4(col, 1.0);
 }

--- a/assets/shaders/procgen_voxels.comp
+++ b/assets/shaders/procgen_voxels.comp
@@ -88,13 +88,22 @@ void main(){
     }else if(P.mode == MODE_TERRAIN){
         float h = fbm(pf.xz * P.terrainFreq) * 20.0 + 20.0;
         if(pf.y < h){ shape = 1u; shapeMat = 1u; }
+
+        // Scatter additional features based on 16x16 cells in the XZ plane.
         vec2 cell2 = floor(pf.xz / 16.0);
         float tn = hash(cell2, float(P.noiseSeed));
         if(tn > 0.85){
+            // Simple foliage clumps
             vec2 center2 = cell2 * 16.0 + 8.0;
             float th = fbm(center2 * P.terrainFreq) * 20.0 + 20.0;
             vec3 tc = vec3(center2.x, th + 6.0, center2.y);
             if(distance(pf, tc) < 3.0){ shape = 1u; shapeMat = 2u; }
+        }else if(tn > 0.75){
+            // Rock outcrops
+            vec2 center2 = cell2 * 16.0 + 8.0;
+            float th = fbm(center2 * P.terrainFreq) * 20.0 + 20.0;
+            vec3 rc = vec3(center2.x, th + 2.0, center2.y);
+            if(distance(pf, rc) < 2.0){ shape = 1u; shapeMat = 3u; }
         }
     }
 


### PR DESCRIPTION
## Summary
- scatter material IDs in procedural voxel generation and emit them to a new sidecar texture
- shade voxels based on material ID, tinting terrain, foliage and rock differently

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "glm")*

------
https://chatgpt.com/codex/tasks/task_e_689b586d395c832a906b3d9b464d6dc5