### PR TITLE
Implement G-buffer and lighting pass

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,13 +53,14 @@ compile_shader(RAY_CS ${SHADER_SRC_DIR}/pp_raycast.comp comp)
 compile_shader(PROCGEN_CS ${SHADER_SRC_DIR}/procgen_voxels.comp comp)
 compile_shader(OCCL1_CS ${SHADER_SRC_DIR}/build_occ_l1.comp comp)
 compile_shader(PRESENT_VS ${SHADER_SRC_DIR}/vs_fullscreen.vert vert)
-compile_shader(PRESENT_FS ${SHADER_SRC_DIR}/fs_present.frag frag)
+compile_shader(RAY_FS ${SHADER_SRC_DIR}/fs_raycast.frag frag)
+compile_shader(LIGHT_FS ${SHADER_SRC_DIR}/fs_lighting.frag frag)
 
-add_custom_target(shaders ALL DEPENDS ${TRI_VS} ${TRI_FS} ${TEX_VS} ${TEX_FS} ${RAY_CS} ${PROCGEN_CS} ${OCCL1_CS} ${PRESENT_VS} ${PRESENT_FS})
+add_custom_target(shaders ALL DEPENDS ${TRI_VS} ${TRI_FS} ${TEX_VS} ${TEX_FS} ${RAY_CS} ${PROCGEN_CS} ${OCCL1_CS} ${PRESENT_VS} ${RAY_FS} ${LIGHT_FS})
 
 # Copy SPIR-V next to vk_app.exe (e.g., build/app/Debug/shaders)
 add_custom_command(TARGET shaders POST_BUILD
   COMMAND ${CMAKE_COMMAND} -E make_directory $<TARGET_FILE_DIR:vk_app>/shaders
     COMMAND ${CMAKE_COMMAND} -E copy_if_different
-            ${TRI_VS} ${TRI_FS} ${TEX_VS} ${TEX_FS} ${RAY_CS} ${PROCGEN_CS} ${OCCL1_CS} ${PRESENT_VS} ${PRESENT_FS} $<TARGET_FILE_DIR:vk_app>/shaders
+            ${TRI_VS} ${TRI_FS} ${TEX_VS} ${TEX_FS} ${RAY_CS} ${PROCGEN_CS} ${OCCL1_CS} ${PRESENT_VS} ${RAY_FS} ${LIGHT_FS} $<TARGET_FILE_DIR:vk_app>/shaders
 )

--- a/assets/shaders/fs_lighting.frag
+++ b/assets/shaders/fs_lighting.frag
@@ -1,0 +1,25 @@
+#version 460
+layout(location=0) out vec4 outColor;
+
+layout(set=0, binding=0, std140) uniform Camera {
+    mat4 invViewProj;
+    vec2 resolution;
+    float time;
+    float debugNormals;
+} cam;
+
+layout(set=0, binding=1) uniform sampler2D gAlbedoRough;
+layout(set=0, binding=2) uniform sampler2D gNormal;
+layout(set=0, binding=3) uniform sampler2D gDepth;
+
+void main() {
+    ivec2 uv = ivec2(gl_FragCoord.xy);
+    vec3 albedo = texelFetch(gAlbedoRough, uv, 0).rgb;
+    vec3 normal = texelFetch(gNormal, uv, 0).xyz;
+    float depth = texelFetch(gDepth, uv, 0).r;
+    vec3 lightDir = normalize(vec3(-0.5, -1.0, -0.3));
+    float ndl = max(dot(normal, -lightDir), 0.0);
+    vec3 color = albedo * ndl;
+    if (cam.debugNormals > 0.5) color = normal * 0.5 + 0.5;
+    outColor = vec4(color, 1.0);
+}

--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -10,6 +10,7 @@ add_library(engine STATIC
   src/gfx/vulkan_commands.cpp
   src/gfx/vulkan_pipeline.cpp
   src/gfx/present_pipeline.cpp
+  src/gfx/ray_pipeline.cpp
   src/gfx/memory.cpp  # empty TU, utilities are header-only
   src/platform/glfw_window.cpp
 )

--- a/engine/include/engine/gfx/present_pipeline.hpp
+++ b/engine/include/engine/gfx/present_pipeline.hpp
@@ -12,13 +12,12 @@ struct PresentPipelineCreateInfo {
   std::string fs_spv;
 };
 
-// Graphics pipeline for a fullscreen triangle performing voxel raycasting.
+// Graphics pipeline for fullscreen lighting of a G-buffer.
 // Descriptor set layout:
 //   set0,binding0 uniform buffer    (CameraUBO)
-//   set0,binding1 uniform buffer    (VoxelAABB)
-//   set0,binding2 combined sampler  (L0 occupancy texture)
-//   set0,binding3 combined sampler  (material texture)
-//   set0,binding4 combined sampler  (L1 occupancy texture)
+//   set0,binding1 combined sampler  (gAlbedoRough)
+//   set0,binding2 combined sampler  (gNormal)
+//   set0,binding3 combined sampler  (gDepth)
 class PresentPipeline {
 public:
   explicit PresentPipeline(const PresentPipelineCreateInfo& ci);

--- a/engine/include/engine/gfx/ray_pipeline.hpp
+++ b/engine/include/engine/gfx/ray_pipeline.hpp
@@ -1,0 +1,42 @@
+#pragma once
+#include <vulkan/vulkan.h>
+#include <string>
+
+namespace engine {
+
+struct RayPipelineCreateInfo {
+  VkDevice device = VK_NULL_HANDLE;
+  VkPipelineCache pipeline_cache = VK_NULL_HANDLE;
+  std::string vs_spv;
+  std::string fs_spv;
+};
+
+// Graphics pipeline for voxel raycasting writing to a G-buffer.
+// Descriptor set layout:
+//   set0,binding0 uniform buffer    (CameraUBO)
+//   set0,binding1 uniform buffer    (VoxelAABB)
+//   set0,binding2 combined sampler  (L0 occupancy texture)
+//   set0,binding3 combined sampler  (material texture)
+//   set0,binding4 combined sampler  (L1 occupancy texture)
+class RayPipeline {
+public:
+  explicit RayPipeline(const RayPipelineCreateInfo& ci);
+  ~RayPipeline();
+
+  RayPipeline(const RayPipeline&) = delete;
+  RayPipeline& operator=(const RayPipeline&) = delete;
+
+  VkPipeline             pipeline()    const { return pipeline_; }
+  VkPipelineLayout       layout()      const { return layout_; }
+  VkDescriptorSetLayout  dset_layout() const { return dset_layout_; }
+
+  VkShaderModule load_module(const std::string& path);
+
+private:
+  VkDevice              dev_ = VK_NULL_HANDLE;
+  VkPipelineLayout      layout_ = VK_NULL_HANDLE;
+  VkPipeline            pipeline_ = VK_NULL_HANDLE;
+  VkDescriptorSetLayout dset_layout_ = VK_NULL_HANDLE;
+};
+
+} // namespace engine


### PR DESCRIPTION
## Summary
- Render G-buffer with albedo, normal and depth from voxel raycast
- Add fullscreen lighting pass with single directional light and optional normal debug view
- Integrate new pipelines and descriptors for geometry and lighting passes

## Testing
- `cmake -S . -B build` *(fails: Could not find package configuration file provided by "glm")*

------
https://chatgpt.com/codex/tasks/task_e_689b5dbd3d48832a98dfa22e563787a9