### PR TITLE
Add basic temporal upscaling with jittered low-res rendering

### DIFF
--- a/assets/shaders/fs_lighting.frag
+++ b/assets/shaders/fs_lighting.frag
@@ -3,12 +3,13 @@ layout(location=0) out vec4 outColor;
 
 layout(set=0, binding=0, std140) uniform Camera {
     mat4 invViewProj;
-    vec2 resolution;
+    vec2 renderResolution;
+    vec2 outputResolution;
     float time;
     float debugNormals;
     float debugLevel;
     float debugSteps;
-    vec2 pad0;
+    vec4 pad0;
 } cam;
 
 layout(set=0, binding=1) uniform sampler2D gAlbedoRough;
@@ -16,14 +17,14 @@ layout(set=0, binding=2) uniform sampler2D gNormal;
 layout(set=0, binding=3) uniform sampler2D gDepth;
 
 void main() {
-    ivec2 uv = ivec2(gl_FragCoord.xy);
-    vec3 albedo = texelFetch(gAlbedoRough, uv, 0).rgb;
+    vec2 uv = gl_FragCoord.xy / cam.outputResolution;
+    vec3 albedo = texture(gAlbedoRough, uv).rgb;
     if (cam.debugLevel > 0.5 || cam.debugSteps > 0.5) {
         outColor = vec4(albedo,1.0);
         return;
     }
-    vec3 normal = texelFetch(gNormal, uv, 0).xyz;
-    float depth = texelFetch(gDepth, uv, 0).r;
+    vec3 normal = texture(gNormal, uv).xyz;
+    float depth = texture(gDepth, uv).r;
     vec3 lightDir = normalize(vec3(-0.5, -1.0, -0.3));
     float ndl = max(dot(normal, -lightDir), 0.0);
     vec3 color = albedo * ndl;

--- a/assets/shaders/fs_raycast.frag
+++ b/assets/shaders/fs_raycast.frag
@@ -5,12 +5,13 @@ layout(location=2) out float outDepth;
 
 layout(set=0, binding=0, std140) uniform Camera {
     mat4 invViewProj;
-    vec2 resolution;
+    vec2 renderResolution;
+    vec2 outputResolution;
     float time;
     float debugNormals; // reused in lighting pass
     float debugLevel;
     float debugSteps;
-    vec2 pad0;
+    vec4 pad0;
 } cam;
 
 layout(set=0, binding=1, std140) uniform VoxelAABB {
@@ -29,7 +30,7 @@ const int STEPS_SCALE = 4;
 struct Ray { vec3 o; vec3 d; };
 
 Ray makeRay(vec2 p) {
-    vec2 ndc = (p / cam.resolution) * 2.0 - 1.0;
+    vec2 ndc = (p / cam.renderResolution) * 2.0 - 1.0;
     vec4 h0 = cam.invViewProj * vec4(ndc, 0.0, 1.0);
     vec4 h1 = cam.invViewProj * vec4(ndc, 1.0, 1.0);
     vec3 ro = h0.xyz / h0.w;


### PR DESCRIPTION
## Summary
- render G-buffer at 0.66× resolution and add Halton-based jitter
- scale geometry pass viewport and sample low-res textures in shaders
- add render and output resolution info to camera uniform

## Testing
- `cmake -S . -B build`
- `cmake --build build`


------
https://chatgpt.com/codex/tasks/task_e_689b69af40a4832a9ba85bc496ac8213