### PR TITLE
Enable fragment storage image writes

### DIFF
--- a/assets/shaders/fs_lighting.frag
+++ b/assets/shaders/fs_lighting.frag
@@ -24,7 +24,7 @@ layout(set=0, binding=4, std140) uniform VoxelAABB {
 
 layout(set=0, binding=5) uniform usampler3D uOccTex;
 layout(set=0, binding=6) uniform usampler3D uOccTexL1;
-layout(set=0, binding=7, r32ui) uniform uimage2D stepsImg;
+layout(set=0, binding=7, r32ui) writeonly uniform uimage2D stepsImg;
 
 const int STEPS_SCALE = 4;
 
@@ -140,7 +140,7 @@ void main() {
         bool hit = gridRaycast(sh, s1, s0);
         int totalSteps = s0 + s1;
         ivec2 coord = ivec2(gl_FragCoord.xy) / STEPS_SCALE;
-        imageAtomicAdd(stepsImg, coord, uint(totalSteps));
+        imageStore(stepsImg, coord, uvec4(uint(totalSteps),0,0,0));
         if(hit) vis = 0.0;
     }
     vec3 color = albedo * ndl * vis;

--- a/assets/shaders/fs_raycast.frag
+++ b/assets/shaders/fs_raycast.frag
@@ -23,7 +23,7 @@ layout(set=0, binding=1, std140) uniform VoxelAABB {
 layout(set=0, binding=2) uniform usampler3D uOccTex;
 layout(set=0, binding=3) uniform usampler3D uMatTex;
 layout(set=0, binding=4) uniform usampler3D uOccTexL1;
-layout(set=0, binding=5, r32ui) uniform uimage2D stepsImg;
+layout(set=0, binding=5, r32ui) writeonly uniform uimage2D stepsImg;
 
 const int STEPS_SCALE = 4;
 
@@ -156,7 +156,7 @@ void main() {
     }
     int totalSteps = steps0 + steps1;
     ivec2 coord = ivec2(gl_FragCoord.xy) / STEPS_SCALE;
-    imageAtomicAdd(stepsImg, coord, uint(totalSteps));
+    imageStore(stepsImg, coord, uvec4(uint(totalSteps),0,0,0));
     vec3 color = albedo;
     if(cam.debugLevel > 0.5) color = (steps0 > 0) ? vec3(0,1,0) : vec3(1,0,0);
     if(cam.debugSteps > 0.5) color = vec3(float(totalSteps) * 0.02);

--- a/engine/src/gfx/vulkan_device.cpp
+++ b/engine/src/gfx/vulkan_device.cpp
@@ -6,6 +6,7 @@
 #include <algorithm>
 #include <fstream>
 #include <cstdint>
+#include <cassert>
 
 namespace engine {
 
@@ -131,6 +132,8 @@ void VulkanDevice::create_logical(bool enable_validation) {
     vkGetPhysicalDeviceFeatures(phys_, &supported);
     if (supported.samplerAnisotropy)
       feats.samplerAnisotropy = VK_TRUE;
+    assert(supported.fragmentStoresAndAtomics == VK_TRUE);
+    feats.fragmentStoresAndAtomics = VK_TRUE;
   
     // Dynamic rendering feature
     VkPhysicalDeviceDynamicRenderingFeatures dyn{ VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DYNAMIC_RENDERING_FEATURES };


### PR DESCRIPTION
## Summary
- enable `fragmentStoresAndAtomics` feature during logical device creation
- mark step log images as write-only and use `imageStore` in raycast and lighting shaders

## Testing
- `cmake -S . -B build`
- `cmake --build build`

------
https://chatgpt.com/codex/tasks/task_e_689b7e2fedd0832a84f8de111755a92e