### PR TITLE
Implement shadow ray traversal with step logging

### DIFF
--- a/assets/shaders/fs_lighting.frag
+++ b/assets/shaders/fs_lighting.frag
@@ -16,18 +16,147 @@ layout(set=0, binding=1) uniform sampler2D gAlbedoRough;
 layout(set=0, binding=2) uniform sampler2D gNormal;
 layout(set=0, binding=3) uniform sampler2D gDepth;
 
+layout(set=0, binding=4, std140) uniform VoxelAABB {
+    vec3 min; float pad0;
+    vec3 max; float pad1;
+    ivec3 dim; int pad2;
+} vox;
+
+layout(set=0, binding=5) uniform usampler3D uOccTex;
+layout(set=0, binding=6) uniform usampler3D uOccTexL1;
+layout(set=0, binding=7, r32ui) uniform uimage2D stepsImg;
+
+const int STEPS_SCALE = 4;
+
+struct Ray { vec3 o; vec3 d; };
+
+Ray makeRay(vec2 p) {
+    vec2 ndc = (p / cam.renderResolution) * 2.0 - 1.0;
+    vec4 h0 = cam.invViewProj * vec4(ndc, 0.0, 1.0);
+    vec4 h1 = cam.invViewProj * vec4(ndc, 1.0, 1.0);
+    vec3 ro = h0.xyz / h0.w;
+    vec3 rd = normalize(h1.xyz / h1.w - ro);
+    return Ray(ro, rd);
+}
+
+bool gridRaycastL0(Ray r, out int steps) {
+    steps = 0;
+    vec3 invD = 1.0 / r.d;
+    vec3 t0s = (vox.min - r.o) * invD;
+    vec3 t1s = (vox.max - r.o) * invD;
+    vec3 tsm = min(t0s, t1s);
+    vec3 tsM = max(t0s, t1s);
+    float t0 = max(max(tsm.x, tsm.y), tsm.z);
+    float t1 = min(min(tsM.x, tsM.y), tsM.z);
+    if (t1 <= max(t0, 0.0)) return false;
+    float t = max(t0, 0.0);
+    vec3 pos = r.o + t * r.d;
+
+    vec3 cellf = (pos - vox.min) / (vox.max - vox.min) * vec3(vox.dim);
+    ivec3 cell = ivec3(clamp(floor(cellf), vec3(0.0), vec3(vox.dim) - vec3(1.0)));
+
+    ivec3 step = ivec3(greaterThan(r.d, vec3(0.0))) * 2 - ivec3(1);
+    vec3 cellSize = (vox.max - vox.min) / vec3(vox.dim);
+    vec3 next = vox.min + (vec3(cell) + (vec3(step)+1.0)*0.5) * cellSize;
+    vec3 tMax = (next - pos) / r.d;
+    vec3 tDelta = cellSize / abs(r.d);
+    for(int i=0;i<1024;i++){
+        if(any(lessThan(cell, ivec3(0))) || any(greaterThanEqual(cell, vox.dim))) break;
+        steps++;
+        if(texelFetch(uOccTex, cell, 0).r > 0u) return true;
+        if(tMax.x < tMax.y){
+            if(tMax.x < tMax.z){
+                cell.x += step.x; t = tMax.x; tMax.x += tDelta.x;
+            }else{
+                cell.z += step.z; t = tMax.z; tMax.z += tDelta.z;
+            }
+        }else{
+            if(tMax.y < tMax.z){
+                cell.y += step.y; t = tMax.y; tMax.y += tDelta.y;
+            }else{
+                cell.z += step.z; t = tMax.z; tMax.z += tDelta.z;
+            }
+        }
+        pos = r.o + t * r.d;
+    }
+    return false;
+}
+
+bool gridRaycast(Ray r, out int stepsL1, out int stepsL0) {
+    stepsL1 = 0;
+    stepsL0 = 0;
+    vec3 invD = 1.0 / r.d;
+    vec3 t0s = (vox.min - r.o) * invD;
+    vec3 t1s = (vox.max - r.o) * invD;
+    vec3 tsm = min(t0s, t1s);
+    vec3 tsM = max(t0s, t1s);
+    float t0 = max(max(tsm.x, tsm.y), tsm.z);
+    float t1 = min(min(tsM.x, tsM.y), tsM.z);
+    if (t1 <= max(t0, 0.0)) return false;
+    float t = max(t0, 0.0);
+    vec3 pos = r.o + t * r.d;
+
+    ivec3 dim1 = textureSize(uOccTexL1, 0);
+    vec3 cellSize = (vox.max - vox.min) / vec3(dim1);
+    vec3 rel = (pos - vox.min) / (vox.max - vox.min);
+    ivec3 cell1 = ivec3(clamp(floor(rel * vec3(dim1)), vec3(0.0), vec3(dim1) - vec3(1.0)));
+    ivec3 step = ivec3(greaterThan(r.d, vec3(0.0))) * 2 - ivec3(1);
+    vec3 next = vox.min + (vec3(cell1) + (vec3(step) + 1.0) * 0.5) * cellSize;
+    vec3 tMax = (next - pos) / r.d;
+    vec3 tDelta = cellSize / abs(r.d);
+    for(int i=0;i<1024;i++){
+        if(any(lessThan(cell1, ivec3(0))) || any(greaterThanEqual(cell1, dim1))) break;
+        if(texelFetch(uOccTexL1, cell1, 0).r > 0u){
+            Ray r2; r2.o = pos; r2.d = r.d;
+            int s0; bool hit = gridRaycastL0(r2, s0);
+            stepsL0 += s0; if(hit) return true; else return false;
+        }
+        stepsL1++;
+        if(tMax.x < tMax.y){
+            if(tMax.x < tMax.z){
+                cell1.x += step.x; t = tMax.x; tMax.x += tDelta.x;
+            }else{
+                cell1.z += step.z; t = tMax.z; tMax.z += tDelta.z;
+            }
+        }else{
+            if(tMax.y < tMax.z){
+                cell1.y += step.y; t = tMax.y; tMax.y += tDelta.y;
+            }else{
+                cell1.z += step.z; t = tMax.z; tMax.z += tDelta.z;
+            }
+        }
+        pos = r.o + t * r.d;
+    }
+    return false;
+}
+
 void main() {
     vec2 uv = gl_FragCoord.xy / cam.outputResolution;
     vec3 albedo = texture(gAlbedoRough, uv).rgb;
-    if (cam.debugLevel > 0.5 || cam.debugSteps > 0.5) {
+    if (cam.debugLevel > 0.5) {
         outColor = vec4(albedo,1.0);
         return;
     }
     vec3 normal = texture(gNormal, uv).xyz;
     float depth = texture(gDepth, uv).r;
+    if (depth == 0.0) {
+        outColor = vec4(albedo,1.0);
+        return;
+    }
     vec3 lightDir = normalize(vec3(-0.5, -1.0, -0.3));
+    vec2 rp = gl_FragCoord.xy / cam.outputResolution * cam.renderResolution;
+    Ray viewRay = makeRay(rp);
+    vec3 pos = viewRay.o + viewRay.d * depth + normal * 0.001;
+    Ray shadowRay; shadowRay.o = pos; shadowRay.d = -lightDir;
+    int steps1; int steps0;
+    bool occluded = gridRaycast(shadowRay, steps1, steps0);
+    int totalSteps = steps0 + steps1;
+    ivec2 coord = ivec2(gl_FragCoord.xy) / STEPS_SCALE;
+    imageAtomicAdd(stepsImg, coord, uint(totalSteps));
     float ndl = max(dot(normal, -lightDir), 0.0);
-    vec3 color = albedo * ndl;
+    float shadow = occluded ? 0.0 : 1.0;
+    vec3 color = albedo * ndl * shadow;
     if (cam.debugNormals > 0.5) color = normal * 0.5 + 0.5;
+    if (cam.debugSteps > 0.5) color = vec3(float(totalSteps) * 0.02);
     outColor = vec4(color, 1.0);
 }

--- a/engine/include/engine/gfx/present_pipeline.hpp
+++ b/engine/include/engine/gfx/present_pipeline.hpp
@@ -18,6 +18,10 @@ struct PresentPipelineCreateInfo {
 //   set0,binding1 combined sampler  (gAlbedoRough)
 //   set0,binding2 combined sampler  (gNormal)
 //   set0,binding3 combined sampler  (gDepth)
+//   set0,binding4 uniform buffer    (VoxelAABB)
+//   set0,binding5 combined sampler  (L0 occupancy texture)
+//   set0,binding6 combined sampler  (L1 occupancy texture)
+//   set0,binding7 storage image     (shadow step count image)
 class PresentPipeline {
 public:
   explicit PresentPipeline(const PresentPipelineCreateInfo& ci);

--- a/engine/src/engine.cpp
+++ b/engine/src/engine.cpp
@@ -84,6 +84,10 @@ struct DrawCtx {
   VkImageView       steps_view  = VK_NULL_HANDLE;
   VkBuffer          steps_buffer = VK_NULL_HANDLE;
   VkExtent2D        steps_dim{0,0};
+  VkImage           shadow_steps_image = VK_NULL_HANDLE;
+  VkImageView       shadow_steps_view  = VK_NULL_HANDLE;
+  VkBuffer          shadow_steps_buffer = VK_NULL_HANDLE;
+  VkExtent2D        shadow_steps_dim{0,0};
   VkExtent2D        ray_extent{0,0};
   VkExtent3D        occ_dim{0,0,0};
   VkExtent3D        dispatch_dim{0,0,0};
@@ -207,18 +211,21 @@ static void record_present(VkCommandBuffer cmd, VkImage, VkImageView view,
                        VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT,
                        0, 0, nullptr, 0, nullptr, 3, post);
 
-  VkImageMemoryBarrier steps_pre{ VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER };
-  steps_pre.srcAccessMask = ctx->first_frame ? 0 : VK_ACCESS_TRANSFER_WRITE_BIT;
-  steps_pre.dstAccessMask = VK_ACCESS_SHADER_WRITE_BIT;
-  steps_pre.oldLayout = ctx->first_frame ? VK_IMAGE_LAYOUT_UNDEFINED : VK_IMAGE_LAYOUT_GENERAL;
-  steps_pre.newLayout = VK_IMAGE_LAYOUT_GENERAL;
-  steps_pre.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
-  steps_pre.subresourceRange.levelCount = 1;
-  steps_pre.subresourceRange.layerCount = 1;
-  steps_pre.image = ctx->steps_image;
+  VkImageMemoryBarrier steps_pre[2]{ { VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER }, { VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER } };
+  for(int i=0;i<2;i++){
+    steps_pre[i].srcAccessMask = ctx->first_frame ? 0 : VK_ACCESS_TRANSFER_WRITE_BIT;
+    steps_pre[i].dstAccessMask = VK_ACCESS_SHADER_WRITE_BIT;
+    steps_pre[i].oldLayout = ctx->first_frame ? VK_IMAGE_LAYOUT_UNDEFINED : VK_IMAGE_LAYOUT_GENERAL;
+    steps_pre[i].newLayout = VK_IMAGE_LAYOUT_GENERAL;
+    steps_pre[i].subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+    steps_pre[i].subresourceRange.levelCount = 1;
+    steps_pre[i].subresourceRange.layerCount = 1;
+  }
+  steps_pre[0].image = ctx->steps_image;
+  steps_pre[1].image = ctx->shadow_steps_image;
   VkPipelineStageFlags stepsSrc = ctx->first_frame ? VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT : VK_PIPELINE_STAGE_TRANSFER_BIT;
   vkCmdPipelineBarrier(cmd, stepsSrc, VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT,
-                       0, 0, nullptr, 0, nullptr, 1, &steps_pre);
+                       0, 0, nullptr, 0, nullptr, 2, steps_pre);
 
   // Prepare G-buffer images for color attachment writes
   VkImageMemoryBarrier gpre[3]{ {VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER}, {VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER}, {VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER} };
@@ -364,6 +371,36 @@ static void record_present(VkCommandBuffer cmd, VkImage, VkImageView view,
                           0, 1, &ctx->light_dset, 0, nullptr);
   vkCmdDraw(cmd, 3, 1, 0, 0);
   vkCmdEndRendering(cmd);
+
+  VkImageMemoryBarrier sh_to_copy{ VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER };
+  sh_to_copy.srcAccessMask = VK_ACCESS_SHADER_WRITE_BIT;
+  sh_to_copy.dstAccessMask = VK_ACCESS_TRANSFER_READ_BIT;
+  sh_to_copy.oldLayout = VK_IMAGE_LAYOUT_GENERAL;
+  sh_to_copy.newLayout = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
+  sh_to_copy.subresourceRange = stepsRange;
+  sh_to_copy.image = ctx->shadow_steps_image;
+  vkCmdPipelineBarrier(cmd, VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT,
+                       0, 0, nullptr, 0, nullptr, 1, &sh_to_copy);
+
+  VkBufferImageCopy bic2{};
+  bic2.imageSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+  bic2.imageSubresource.layerCount = 1;
+  bic2.imageExtent = { ctx->shadow_steps_dim.width, ctx->shadow_steps_dim.height, 1 };
+  vkCmdCopyImageToBuffer(cmd, ctx->shadow_steps_image, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
+                         ctx->shadow_steps_buffer, 1, &bic2);
+
+  VkImageMemoryBarrier sh_to_clear{ VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER };
+  sh_to_clear.srcAccessMask = VK_ACCESS_TRANSFER_READ_BIT;
+  sh_to_clear.dstAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
+  sh_to_clear.oldLayout = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
+  sh_to_clear.newLayout = VK_IMAGE_LAYOUT_GENERAL;
+  sh_to_clear.subresourceRange = stepsRange;
+  sh_to_clear.image = ctx->shadow_steps_image;
+  vkCmdPipelineBarrier(cmd, VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT,
+                       0, 0, nullptr, 0, nullptr, 1, &sh_to_clear);
+
+  vkCmdClearColorImage(cmd, ctx->shadow_steps_image, VK_IMAGE_LAYOUT_GENERAL,
+                       &zero, 1, &stepsRange);
 
   ctx->first_frame = false;
 }
@@ -621,9 +658,9 @@ int run() {
   // Descriptor pool for geometry and lighting passes
   {
     VkDescriptorPoolSize sizes[3]{};
-    sizes[0].type = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER; sizes[0].descriptorCount = 3;
-    sizes[1].type = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER; sizes[1].descriptorCount = 6;
-    sizes[2].type = VK_DESCRIPTOR_TYPE_STORAGE_IMAGE; sizes[2].descriptorCount = 1;
+    sizes[0].type = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER; sizes[0].descriptorCount = 4;
+    sizes[1].type = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER; sizes[1].descriptorCount = 8;
+    sizes[2].type = VK_DESCRIPTOR_TYPE_STORAGE_IMAGE; sizes[2].descriptorCount = 2;
     VkDescriptorPoolCreateInfo dpci{ VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO };
     dpci.flags = VK_DESCRIPTOR_POOL_CREATE_FREE_DESCRIPTOR_SET_BIT;
     dpci.maxSets = 2; dpci.poolSizeCount = 3; dpci.pPoolSizes = sizes;
@@ -634,11 +671,14 @@ int run() {
   Image2D g_normal_img{};
   Image2D g_depth_img{};
   Image2D steps_img{};
+  Image2D shadow_steps_img{};
   VkImageView g_albedo_view = VK_NULL_HANDLE;
   VkImageView g_normal_view = VK_NULL_HANDLE;
   VkImageView g_depth_view = VK_NULL_HANDLE;
   VkImageView steps_view = VK_NULL_HANDLE;
+  VkImageView shadow_steps_view = VK_NULL_HANDLE;
   Buffer steps_buf{};
+  Buffer shadow_steps_buf{};
 
   auto destroy_swapchain_stack = [&]() {
     if (ray_dset) { vkFreeDescriptorSets(device.device(), dpool, 1, &ray_dset); ray_dset = VK_NULL_HANDLE; }
@@ -647,8 +687,10 @@ int run() {
     if (g_normal_view) vkDestroyImageView(device.device(), g_normal_view, nullptr);
     if (g_depth_view) vkDestroyImageView(device.device(), g_depth_view, nullptr);
     if (steps_view) vkDestroyImageView(device.device(), steps_view, nullptr);
+    if (shadow_steps_view) vkDestroyImageView(device.device(), shadow_steps_view, nullptr);
     destroy_image2d(allocator.raw(), g_albedo_img); destroy_image2d(allocator.raw(), g_normal_img); destroy_image2d(allocator.raw(), g_depth_img);
     destroy_image2d(allocator.raw(), steps_img); destroy_buffer(allocator.raw(), steps_buf);
+    destroy_image2d(allocator.raw(), shadow_steps_img); destroy_buffer(allocator.raw(), shadow_steps_buf);
     commands.reset();
     swapchain.reset();
   };
@@ -703,6 +745,13 @@ int run() {
     steps_buf = create_host_buffer(allocator.raw(), steps_w * steps_h * sizeof(uint32_t),
                                    VK_BUFFER_USAGE_TRANSFER_DST_BIT);
 
+    shadow_steps_img = create_image2d(allocator.raw(), steps_w, steps_h, VK_FORMAT_R32_UINT,
+                                      VK_IMAGE_USAGE_STORAGE_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT);
+    svi.image = shadow_steps_img.image; svi.format = VK_FORMAT_R32_UINT;
+    VK_CHECK(vkCreateImageView(device.device(), &svi, nullptr, &shadow_steps_view));
+    shadow_steps_buf = create_host_buffer(allocator.raw(), steps_w * steps_h * sizeof(uint32_t),
+                                         VK_BUFFER_USAGE_TRANSFER_DST_BIT);
+
     VkDescriptorBufferInfo cam_bi{}; cam_bi.buffer = cam_buf.buffer; cam_bi.range = sizeof(CameraUBO);
     VkDescriptorBufferInfo vox_bi{}; vox_bi.buffer = vox_buf.buffer; vox_bi.range = sizeof(VoxelAABB);
     VkDescriptorImageInfo occ_info{}; occ_info.sampler = nearest_sampler; occ_info.imageView = occ_view; occ_info.imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
@@ -739,19 +788,25 @@ int run() {
     VkDescriptorImageInfo albedo_info{}; albedo_info.sampler = linear_sampler; albedo_info.imageView = g_albedo_view; albedo_info.imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
     VkDescriptorImageInfo normal_info{}; normal_info.sampler = linear_sampler; normal_info.imageView = g_normal_view; normal_info.imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
     VkDescriptorImageInfo depth_info{}; depth_info.sampler = linear_sampler; depth_info.imageView = g_depth_view; depth_info.imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+    VkDescriptorImageInfo shadow_steps_info{}; shadow_steps_info.imageView = shadow_steps_view; shadow_steps_info.imageLayout = VK_IMAGE_LAYOUT_GENERAL;
 
-    VkWriteDescriptorSet lwrites[4]{};
+    VkWriteDescriptorSet lwrites[8]{};
     lwrites[0].sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET; lwrites[0].dstSet = light_dset; lwrites[0].dstBinding = 0; lwrites[0].descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER; lwrites[0].descriptorCount = 1; lwrites[0].pBufferInfo = &cam_bi;
     lwrites[1].sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET; lwrites[1].dstSet = light_dset; lwrites[1].dstBinding = 1; lwrites[1].descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER; lwrites[1].descriptorCount = 1; lwrites[1].pImageInfo = &albedo_info;
     lwrites[2].sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET; lwrites[2].dstSet = light_dset; lwrites[2].dstBinding = 2; lwrites[2].descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER; lwrites[2].descriptorCount = 1; lwrites[2].pImageInfo = &normal_info;
     lwrites[3].sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET; lwrites[3].dstSet = light_dset; lwrites[3].dstBinding = 3; lwrites[3].descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER; lwrites[3].descriptorCount = 1; lwrites[3].pImageInfo = &depth_info;
-    vkUpdateDescriptorSets(device.device(), 4, lwrites, 0, nullptr);
+    lwrites[4].sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET; lwrites[4].dstSet = light_dset; lwrites[4].dstBinding = 4; lwrites[4].descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER; lwrites[4].descriptorCount = 1; lwrites[4].pBufferInfo = &vox_bi;
+    lwrites[5].sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET; lwrites[5].dstSet = light_dset; lwrites[5].dstBinding = 5; lwrites[5].descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER; lwrites[5].descriptorCount = 1; lwrites[5].pImageInfo = &occ_info;
+    lwrites[6].sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET; lwrites[6].dstSet = light_dset; lwrites[6].dstBinding = 6; lwrites[6].descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER; lwrites[6].descriptorCount = 1; lwrites[6].pImageInfo = &occ_l1_info;
+    lwrites[7].sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET; lwrites[7].dstSet = light_dset; lwrites[7].dstBinding = 7; lwrites[7].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_IMAGE; lwrites[7].descriptorCount = 1; lwrites[7].pImageInfo = &shadow_steps_info;
+    vkUpdateDescriptorSets(device.device(), 8, lwrites, 0, nullptr);
 
     ctx.ray_pipe = ray_pipeline.get(); ctx.ray_dset = ray_dset;
     ctx.light_pipe = present_pipeline.get(); ctx.light_dset = light_dset;
     ctx.g_albedo = g_albedo_img.image; ctx.g_normal = g_normal_img.image; ctx.g_depth = g_depth_img.image;
     ctx.g_albedo_view = g_albedo_view; ctx.g_normal_view = g_normal_view; ctx.g_depth_view = g_depth_view;
     ctx.steps_image = steps_img.image; ctx.steps_view = steps_view; ctx.steps_buffer = steps_buf.buffer; ctx.steps_dim = {steps_w, steps_h};
+    ctx.shadow_steps_image = shadow_steps_img.image; ctx.shadow_steps_view = shadow_steps_view; ctx.shadow_steps_buffer = shadow_steps_buf.buffer; ctx.shadow_steps_dim = {steps_w, steps_h};
     ctx.ray_extent = {rw, rh};
     ctx.first_frame = true;
   };
@@ -928,7 +983,19 @@ int run() {
     float avg_steps = static_cast<float>(sum) /
                       (static_cast<float>(swapchain->extent().width) * static_cast<float>(swapchain->extent().height));
     float max_steps = static_cast<float>(maxv) / static_cast<float>(kStepsDown * kStepsDown);
-    spdlog::info("avg_steps {:.2f} max_steps {:.2f}", avg_steps, max_steps);
+
+    void* mapped_s = nullptr;
+    vmaMapMemory(allocator.raw(), shadow_steps_buf.allocation, &mapped_s);
+    uint32_t* stepDataS = static_cast<uint32_t*>(mapped_s);
+    uint64_t sum_s = 0; uint32_t maxv_s = 0;
+    uint32_t cells_s = ctx.shadow_steps_dim.width * ctx.shadow_steps_dim.height;
+    for(uint32_t i=0;i<cells_s;i++){ sum_s += stepDataS[i]; if(stepDataS[i] > maxv_s) maxv_s = stepDataS[i]; }
+    vmaUnmapMemory(allocator.raw(), shadow_steps_buf.allocation);
+    float avg_steps_s = static_cast<float>(sum_s) /
+                        (static_cast<float>(swapchain->extent().width) * static_cast<float>(swapchain->extent().height));
+    float max_steps_s = static_cast<float>(maxv_s) / static_cast<float>(kStepsDown * kStepsDown);
+    spdlog::info("avg_steps {:.2f} max_steps {:.2f} shadow_avg {:.2f} shadow_max {:.2f}",
+                 avg_steps, max_steps, avg_steps_s, max_steps_s);
 
     std::this_thread::sleep_for(1ms);
   }

--- a/engine/src/gfx/present_pipeline.cpp
+++ b/engine/src/gfx/present_pipeline.cpp
@@ -29,7 +29,7 @@ VkShaderModule PresentPipeline::load_module(const std::string& path) {
 PresentPipeline::PresentPipeline(const PresentPipelineCreateInfo& ci)
   : dev_(ci.device), color_format_(ci.color_format) {
   // Descriptor set layout for camera UBO and G-buffer textures
-  VkDescriptorSetLayoutBinding binds[4]{};
+  VkDescriptorSetLayoutBinding binds[8]{};
   binds[0].binding = 0;
   binds[0].descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
   binds[0].descriptorCount = 1;
@@ -50,8 +50,28 @@ PresentPipeline::PresentPipeline(const PresentPipelineCreateInfo& ci)
   binds[3].descriptorCount = 1;
   binds[3].stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT;
 
+  binds[4].binding = 4;
+  binds[4].descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
+  binds[4].descriptorCount = 1;
+  binds[4].stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT;
+
+  binds[5].binding = 5;
+  binds[5].descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
+  binds[5].descriptorCount = 1;
+  binds[5].stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT;
+
+  binds[6].binding = 6;
+  binds[6].descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
+  binds[6].descriptorCount = 1;
+  binds[6].stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT;
+
+  binds[7].binding = 7;
+  binds[7].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_IMAGE;
+  binds[7].descriptorCount = 1;
+  binds[7].stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT;
+
   VkDescriptorSetLayoutCreateInfo dlci{ VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO };
-  dlci.bindingCount = 4; dlci.pBindings = binds;
+  dlci.bindingCount = 8; dlci.pBindings = binds;
   VK_CHECK(vkCreateDescriptorSetLayout(dev_, &dlci, nullptr, &dset_layout_));
 
   // Pipeline layout: only descriptor set layout (no push constants)


### PR DESCRIPTION
## Summary
- Cast hard shadow rays in lighting shader using hierarchical voxel grid
- Extend present pipeline & engine to bind voxel data and record shadow step counts

## Testing
- `cmake -S . -B build`
- `cmake --build build`


------
https://chatgpt.com/codex/tasks/task_e_689b89e405d0832abae8ceac4d36930e