### PR TITLE
Enable fragment storage operations

### DIFF
--- a/engine/src/gfx/vulkan_device.cpp
+++ b/engine/src/gfx/vulkan_device.cpp
@@ -131,6 +131,8 @@ void VulkanDevice::create_logical(bool enable_validation) {
     vkGetPhysicalDeviceFeatures(phys_, &supported);
     if (supported.samplerAnisotropy)
       feats.samplerAnisotropy = VK_TRUE;
+    if (supported.fragmentStoresAndAtomics)
+      feats.fragmentStoresAndAtomics = VK_TRUE;
   
     // Dynamic rendering feature
     VkPhysicalDeviceDynamicRenderingFeatures dyn{ VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DYNAMIC_RENDERING_FEATURES };


### PR DESCRIPTION
## Summary
- allow fragment shader to write to storage images by enabling `fragmentStoresAndAtomics` device feature

## Testing
- `cmake -S . -B build`
- `cmake --build build`

------
https://chatgpt.com/codex/tasks/task_e_689b8d97b280832a8085b87ad9803a73