### PR TITLE
Fix shadow ray origin and continue traversal on L0 miss

### DIFF
--- a/assets/shaders/fs_raycast.frag
+++ b/assets/shaders/fs_raycast.frag
@@ -109,11 +109,13 @@ bool gridRaycast(Ray r, out ivec3 cell, out int hitFace, out float tHit, out int
     for(int i=0;i<1024;i++){
         if(any(lessThan(cell1, ivec3(0))) || any(greaterThanEqual(cell1, dim1))) break;
         if(texelFetch(uOccTexL1, cell1, 0).r > 0u){
-            Ray r2; r2.o = pos; r2.d = r.d;
+            // Start slightly inside this L1 cell to avoid re-testing boundary
+            Ray r2; r2.o = pos + r.d * 1e-3; r2.d = r.d;
             float tLocal; int s0;
             bool hit = gridRaycastL0(r2, cell, hitFace, tLocal, s0);
             stepsL0 += s0;
-            if(hit){ tHit = t + tLocal; return true; } else return false;
+            if(hit){ tHit = t + tLocal; return true; }
+            // MISS -> keep marching to next L1 cell
         }
         stepsL1++;
         if(tMax.x < tMax.y){


### PR DESCRIPTION
## Summary
- Offset shadow rays along light direction to avoid self-occlusion
- Continue L1 traversal after L0 miss by offsetting inside the cell

## Testing
- `glslangValidator -V assets/shaders/fs_lighting.frag`
- `glslangValidator -V assets/shaders/fs_raycast.frag`
- `cmake -S . -B build`
- `cmake --build build` *(fails: Interrupt)*

------
https://chatgpt.com/codex/tasks/task_e_689b92973b30832aa52026b6ad574e32