### PR TITLE
Fix raycast face indices for correct normals

### DIFF
--- a/assets/shaders/fs_raycast.frag
+++ b/assets/shaders/fs_raycast.frag
@@ -67,15 +67,15 @@ bool gridRaycastL0(Ray r, out ivec3 cell, out int hitFace, out float tHit, out i
         if(texelFetch(uOccTex, cell, 0).r > 0u){ tHit = t; return true; }
         if(tMax.x < tMax.y){
             if(tMax.x < tMax.z){
-                cell.x += step.x; t = tMax.x; tMax.x += tDelta.x; hitFace = step.x > 0 ? 0 : 1;
+                cell.x += step.x; t = tMax.x; tMax.x += tDelta.x; hitFace = step.x > 0 ? 1 : 0;
             }else{
-                cell.z += step.z; t = tMax.z; tMax.z += tDelta.z; hitFace = step.z > 0 ? 4 : 5;
+                cell.z += step.z; t = tMax.z; tMax.z += tDelta.z; hitFace = step.z > 0 ? 5 : 4;
             }
         }else{
             if(tMax.y < tMax.z){
-                cell.y += step.y; t = tMax.y; tMax.y += tDelta.y; hitFace = step.y > 0 ? 2 : 3;
+                cell.y += step.y; t = tMax.y; tMax.y += tDelta.y; hitFace = step.y > 0 ? 3 : 2;
             }else{
-                cell.z += step.z; t = tMax.z; tMax.z += tDelta.z; hitFace = step.z > 0 ? 4 : 5;
+                cell.z += step.z; t = tMax.z; tMax.z += tDelta.z; hitFace = step.z > 0 ? 5 : 4;
             }
         }
         pos = r.o + t * r.d;


### PR DESCRIPTION
## Summary
- Swap face indices in `gridRaycastL0` to ensure terrain normals point outward.

## Testing
- `cmake --build build --target shaders -j`
- `cmake --build build -j`
- `./build/app/vk_app` *(fails: GLFW init failed)*

------
https://chatgpt.com/codex/tasks/task_e_689ba2c9ddac832abe3832d6d538da68