### PR TITLE
Add shared SPIR-V loading utility

### DIFF
--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -11,6 +11,7 @@ add_library(engine STATIC
   src/gfx/vulkan_pipeline.cpp
   src/gfx/present_pipeline.cpp
   src/gfx/ray_pipeline.cpp
+  src/gfx/utils.cpp
   src/gfx/memory.cpp  # empty TU, utilities are header-only
   src/platform/glfw_window.cpp
 )

--- a/engine/include/engine/gfx/utils.hpp
+++ b/engine/include/engine/gfx/utils.hpp
@@ -1,0 +1,10 @@
+#pragma once
+#include <string>
+#include <vector>
+
+namespace engine {
+
+std::vector<char> load_spirv_file(const std::string& path);
+
+} // namespace engine
+

--- a/engine/src/gfx/present_pipeline.cpp
+++ b/engine/src/gfx/present_pipeline.cpp
@@ -1,23 +1,11 @@
 #include <engine/gfx/present_pipeline.hpp>
 #include <engine/vk_checks.hpp>
-#include <spdlog/spdlog.h>
-#include <fstream>
-#include <vector>
+#include <engine/gfx/utils.hpp>
 
 namespace engine {
 
-static std::vector<char> read_binary(const std::string& path) {
-  std::ifstream f(path, std::ios::ate | std::ios::binary);
-  if (!f) { spdlog::error("[vk] Failed to open SPIR-V: {}", path); std::abort(); }
-  size_t size = static_cast<size_t>(f.tellg());
-  std::vector<char> data(size);
-  f.seekg(0);
-  f.read(data.data(), size);
-  return data;
-}
-
 VkShaderModule PresentPipeline::load_module(const std::string& path) {
-  auto bytes = read_binary(path);
+  auto bytes = load_spirv_file(path);
   VkShaderModuleCreateInfo ci{ VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO };
   ci.codeSize = bytes.size();
   ci.pCode = reinterpret_cast<const uint32_t*>(bytes.data());

--- a/engine/src/gfx/ray_pipeline.cpp
+++ b/engine/src/gfx/ray_pipeline.cpp
@@ -1,23 +1,11 @@
 #include <engine/gfx/ray_pipeline.hpp>
 #include <engine/vk_checks.hpp>
-#include <spdlog/spdlog.h>
-#include <fstream>
-#include <vector>
+#include <engine/gfx/utils.hpp>
 
 namespace engine {
 
-static std::vector<char> read_binary(const std::string& path) {
-  std::ifstream f(path, std::ios::ate | std::ios::binary);
-  if (!f) { spdlog::error("[vk] Failed to open SPIR-V: {}", path); std::abort(); }
-  size_t size = static_cast<size_t>(f.tellg());
-  std::vector<char> data(size);
-  f.seekg(0);
-  f.read(data.data(), size);
-  return data;
-}
-
 VkShaderModule RayPipeline::load_module(const std::string& path) {
-  auto bytes = read_binary(path);
+  auto bytes = load_spirv_file(path);
   VkShaderModuleCreateInfo ci{ VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO };
   ci.codeSize = bytes.size();
   ci.pCode = reinterpret_cast<const uint32_t*>(bytes.data());

--- a/engine/src/gfx/utils.cpp
+++ b/engine/src/gfx/utils.cpp
@@ -1,0 +1,21 @@
+#include <engine/gfx/utils.hpp>
+#include <spdlog/spdlog.h>
+#include <fstream>
+
+namespace engine {
+
+std::vector<char> load_spirv_file(const std::string& path) {
+  std::ifstream f(path, std::ios::ate | std::ios::binary);
+  if (!f) {
+    spdlog::error("[vk] Failed to open SPIR-V: {}", path);
+    std::abort();
+  }
+  size_t size = static_cast<size_t>(f.tellg());
+  std::vector<char> data(size);
+  f.seekg(0);
+  f.read(data.data(), size);
+  return data;
+}
+
+} // namespace engine
+

--- a/engine/src/gfx/vulkan_pipeline.cpp
+++ b/engine/src/gfx/vulkan_pipeline.cpp
@@ -1,23 +1,11 @@
 #include <engine/gfx/vulkan_pipeline.hpp>
 #include <engine/vk_checks.hpp>
-#include <spdlog/spdlog.h>
-#include <fstream>
-#include <vector>
+#include <engine/gfx/utils.hpp>
 
 namespace engine {
 
-static std::vector<char> read_binary(const std::string& path) {
-  std::ifstream f(path, std::ios::ate | std::ios::binary);
-  if (!f) { spdlog::error("[vk] Failed to open SPIR-V: {}", path); std::abort(); }
-  size_t size = static_cast<size_t>(f.tellg());
-  std::vector<char> data(size);
-  f.seekg(0);
-  f.read(data.data(), size);
-  return data;
-}
-
 VkShaderModule TrianglePipeline::load_module(const std::string& path) {
-  auto bytes = read_binary(path);
+  auto bytes = load_spirv_file(path);
   VkShaderModuleCreateInfo ci{ VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO };
   ci.codeSize = bytes.size();
   ci.pCode = reinterpret_cast<const uint32_t*>(bytes.data());


### PR DESCRIPTION
## Summary
- add `load_spirv_file` utility for reading SPIR-V binaries
- refactor pipeline implementations to use the shared loader
- wire new utility into build system

## Testing
- `cmake -S . -B build`
- `cmake --build build`


------
https://chatgpt.com/codex/tasks/task_e_689baab64038832a91e978a7265dcdb2