### PR TITLE
Set one-time submit flag for command buffers

### DIFF
--- a/engine/src/gfx/vulkan_commands.cpp
+++ b/engine/src/gfx/vulkan_commands.cpp
@@ -83,6 +83,7 @@ uint32_t VulkanCommands::acquire_record_present(
   // Record commands
   VK_CHECK(vkResetCommandBuffer(f.cmd, 0));
   VkCommandBufferBeginInfo bi{ VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO };
+  bi.flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT;
   VK_CHECK(vkBeginCommandBuffer(f.cmd, &bi));
 
   // Transition: PRESENT -> COLOR_ATTACHMENT_OPTIMAL (or UNDEFINED on first use)


### PR DESCRIPTION
## Summary
- use `VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT` when beginning swapchain command buffers

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `VK_INSTANCE_LAYERS=VK_LAYER_KHRONOS_validation xvfb-run -a ./build/app/vk_app` *(fails: Failed to open SPIR-V: /workspace/vk-engine/shaders/procgen_voxels.comp.spv)*

------
https://chatgpt.com/codex/tasks/task_e_689bbf63dad4832aabfb34402a56fe40