### PR TITLE
Implement ring-buffer staging for GPU uploads

### DIFF
--- a/engine/src/engine.cpp
+++ b/engine/src/engine.cpp
@@ -495,7 +495,8 @@ int run() {
 
   GpuAllocator allocator;
   allocator.init(instance.vk(), device.physical(), device.device());
-  TransferContext transfer{device.device(), device.graphics_family()};
+  TransferContext transfer{device.device(), device.graphics_family(),
+                           allocator.raw()};
 
   // Samplers for sampled images
   UniqueSampler linear_sampler;


### PR DESCRIPTION
## Summary
- allocate a persistent 8 MB host-visible staging buffer managed by a fence-backed ring allocator
- copy buffer and 3D image uploads through the ring buffer to avoid per-upload allocations
- forward allocator to transfer context during engine init

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "glm")*

------
https://chatgpt.com/codex/tasks/task_e_689bc177dd9c832ab0f07fd17c73c151