### PR TITLE
Expose precomputed L1 grid params to raycast shader

### DIFF
--- a/assets/shaders/fs_raycast.frag
+++ b/assets/shaders/fs_raycast.frag
@@ -18,6 +18,8 @@ layout(set=0, binding=1, std140) uniform VoxelAABB {
     vec3 min; float pad0;
     vec3 max; float pad1;
     ivec3 dim; int pad2;
+    ivec3 occL1Dim; int pad3;
+    vec3 occL1CellSize; float pad4;
 } vox;
 
 layout(set=0, binding=2) uniform usampler3D uOccTex;
@@ -98,10 +100,10 @@ bool gridRaycast(Ray r, out ivec3 cell, out int hitFace, out float tHit, out int
     float t = max(t0, 0.0);
     vec3 pos = r.o + t * r.d;
 
-    ivec3 dim1 = textureSize(uOccTexL1, 0);
-    vec3 cellSize = (vox.max - vox.min) / vec3(dim1);
-    vec3 rel = (pos - vox.min) / (vox.max - vox.min);
-    ivec3 cell1 = ivec3(clamp(floor(rel * vec3(dim1)), vec3(0.0), vec3(dim1) - vec3(1.0)));
+    ivec3 dim1 = vox.occL1Dim;
+    vec3 cellSize = vox.occL1CellSize;
+    vec3 cellf = (pos - vox.min) / cellSize;
+    ivec3 cell1 = ivec3(clamp(floor(cellf), vec3(0.0), vec3(dim1) - vec3(1.0)));
     ivec3 step = ivec3(greaterThan(r.d, vec3(0.0))) * 2 - ivec3(1);
     vec3 next = vox.min + (vec3(cell1) + (vec3(step) + 1.0) * 0.5) * cellSize;
     vec3 tMax = (next - pos) / r.d;

--- a/engine/src/engine.cpp
+++ b/engine/src/engine.cpp
@@ -115,6 +115,10 @@ struct VoxelAABB {
   float pad1 = 0.0f;
   glm::ivec3 dim{0};
   int pad2 = 0;
+  glm::ivec3 occL1Dim{0};
+  int pad3 = 0;
+  glm::vec3 occL1CellSize{0.0f};
+  float pad4 = 0.0f;
 };
 
 struct VoxParams {
@@ -545,6 +549,7 @@ int run() {
   Buffer vox_params_buf = create_buffer(allocator.raw(), sizeof(VoxParams),
                                         VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT);
   const uint32_t N = 128;
+  const uint32_t N1 = N / 4;
   Image3D occ_img{};
   Image3D mat_img{};
   Image3D occ_l1_img{};
@@ -570,7 +575,6 @@ int run() {
     VK_CHECK(vkCreateImageView(device.device(), &ovi, nullptr,
                                occ_storage_view.init(device.device())));
 
-    const uint32_t N1 = N / 4;
     occ_l1_img =
         create_image3d(allocator.raw(), N1, N1, N1, VK_FORMAT_R8_UINT,
                        VK_IMAGE_USAGE_STORAGE_BIT | VK_IMAGE_USAGE_SAMPLED_BIT);
@@ -596,6 +600,9 @@ int run() {
   vubo.max = {static_cast<float>(N), static_cast<float>(N),
               static_cast<float>(N)};
   vubo.dim = {static_cast<int>(N), static_cast<int>(N), static_cast<int>(N)};
+  vubo.occL1Dim = {static_cast<int>(N1), static_cast<int>(N1), static_cast<int>(N1)};
+  vubo.occL1CellSize =
+      (vubo.max - vubo.min) / glm::vec3(vubo.occL1Dim);
   upload_buffer(allocator.raw(), transfer, device.graphics_queue(), vox_buf,
                 &vubo, sizeof(vubo));
 


### PR DESCRIPTION
## Summary
- add precomputed L1 grid dimensions and cell size to VoxelAABB uniform
- consume L1 grid parameters in raycast shader instead of `textureSize`

## Testing
- `glslangValidator -V assets/shaders/fs_raycast.frag -o /tmp/fs_raycast.spv`
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "glm")*

------
https://chatgpt.com/codex/tasks/task_e_689bc979316c832a91823f333c53f45c