### PR TITLE
Add RAII wrapper for GLFW initialization

### DIFF
--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -13,6 +13,7 @@ add_library(engine STATIC
   src/gfx/ray_pipeline.cpp
   src/gfx/utils.cpp
   src/gfx/memory.cpp  # empty TU, utilities are header-only
+  src/platform/glfw_context.cpp
   src/platform/glfw_window.cpp
 )
 

--- a/engine/src/platform/glfw_context.cpp
+++ b/engine/src/platform/glfw_context.cpp
@@ -1,0 +1,24 @@
+#include "glfw_context.hpp"
+#include <GLFW/glfw3.h>
+#include <stdexcept>
+
+namespace engine {
+
+std::mutex GlfwContext::mtx_{};
+uint32_t GlfwContext::ref_count_ = 0;
+
+GlfwContext::GlfwContext() {
+  std::lock_guard<std::mutex> lock(mtx_);
+  if (ref_count_ == 0) {
+    if (!glfwInit()) throw std::runtime_error("GLFW init failed");
+  }
+  ++ref_count_;
+}
+
+GlfwContext::~GlfwContext() {
+  std::lock_guard<std::mutex> lock(mtx_);
+  if (--ref_count_ == 0) glfwTerminate();
+}
+
+} // namespace engine
+

--- a/engine/src/platform/glfw_context.hpp
+++ b/engine/src/platform/glfw_context.hpp
@@ -1,0 +1,18 @@
+#pragma once
+#include <mutex>
+#include <cstdint>
+
+namespace engine {
+
+class GlfwContext {
+public:
+  GlfwContext();
+  ~GlfwContext();
+
+private:
+  static std::mutex mtx_;
+  static uint32_t ref_count_;
+};
+
+} // namespace engine
+

--- a/engine/src/platform/glfw_window.cpp
+++ b/engine/src/platform/glfw_window.cpp
@@ -3,17 +3,17 @@
 #include <GLFW/glfw3.h>
 #include <stdexcept>
 #include <vector>
+#include "glfw_context.hpp"
 
 namespace engine {
 
 class GlfwWindow final : public IWindow {
 public:
-  explicit GlfwWindow(const WindowDesc& d) {
-    if (!glfwInit()) throw std::runtime_error("GLFW init failed");
+  explicit GlfwWindow(const WindowDesc& d) : ctx_() {
     glfwWindowHint(GLFW_CLIENT_API, GLFW_NO_API);
     glfwWindowHint(GLFW_RESIZABLE, d.resizable ? GLFW_TRUE : GLFW_FALSE);
     handle_ = glfwCreateWindow((int)d.width, (int)d.height, d.title.c_str(), nullptr, nullptr);
-    if (!handle_) { glfwTerminate(); throw std::runtime_error("GLFW window creation failed"); }
+    if (!handle_) throw std::runtime_error("GLFW window creation failed");
 
     glfwSetFramebufferSizeCallback(handle_, [](GLFWwindow*, int x, int y){
       spdlog::trace("[event] framebuffer resize: {}x{}", x, y);
@@ -30,7 +30,6 @@ public:
     if (handle_) {
       spdlog::info("Destroying window");
       glfwDestroyWindow(handle_);
-      glfwTerminate();
     }
   }
 
@@ -43,6 +42,7 @@ public:
   void* native_handle() const override { return handle_; }
 
 private:
+  GlfwContext ctx_;
   GLFWwindow* handle_ = nullptr;
 };
 
@@ -51,6 +51,7 @@ std::unique_ptr<IWindow> create_window(const WindowDesc& desc) {
 }
 
 std::vector<const char*> platform_required_instance_extensions() {
+  GlfwContext ctx;
   uint32_t count = 0;
   const char** ext = glfwGetRequiredInstanceExtensions(&count);
   std::vector<const char*> out;


### PR DESCRIPTION
## Summary
- add `GlfwContext` RAII helper to init/terminate GLFW via reference counting
- refactor `GlfwWindow` to use `GlfwContext` instead of calling `glfwInit`/`glfwTerminate`
- ensure required instance extensions query also uses the GLFW context

## Testing
- `cmake -B build -S .`
- `cmake --build build`

------
https://chatgpt.com/codex/tasks/task_e_689c6c24f2c4832abb517337cb783b2f