### PR TITLE
Fix missing Vulkan debug utils linkage

### DIFF
--- a/engine/src/render_loop.cpp
+++ b/engine/src/render_loop.cpp
@@ -2,6 +2,7 @@
 #include <engine/config.hpp>
 #include <engine/gfx/present_pipeline.hpp>
 #include <engine/gfx/ray_pipeline.hpp>
+#include <engine/gfx/vulkan_instance.hpp>
 
 namespace engine {
 


### PR DESCRIPTION
## Summary
- include Vulkan instance header in render loop to use debug marker function pointers

## Testing
- `cmake -S . -B build`
- `cmake --build build`

------
https://chatgpt.com/codex/tasks/task_e_689c732cf164832a9a45e9f4b548874c